### PR TITLE
Refactor kaitai wrapper

### DIFF
--- a/mdp-webui/src/lib/kaitai-wrapper.js
+++ b/mdp-webui/src/lib/kaitai-wrapper.js
@@ -1,9 +1,9 @@
 // Wrapper to handle Kaitai's UMD module format in Vite
 
-// Import and execute the UMD modules (they will set window.KaitaiStream and window.MiniwareMdpM01)
-await import('kaitai-struct/KaitaiStream.js');
-await import('./kaitai/MiniwareMdpM01.js');
+// Import the UMD modules so they register themselves on `window`
+import 'kaitai-struct/KaitaiStream.js';
+import './kaitai/MiniwareMdpM01.js';
 
-// Export from window (UMD modules set these)
+// Re-export the objects that the UMD modules attach to `window`
 export const KaitaiStream = window.KaitaiStream;
 export const MiniwareMdpM01 = window.MiniwareMdpM01;


### PR DESCRIPTION
## Summary
- drop top-level await in `kaitai-wrapper.js`
- import UMD modules directly and re-export parsed objects

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68730c7cd3608331b7898c7a225ab469