### PR TITLE
Fix deprecated string usage

### DIFF
--- a/mdp-webui/src/lib/stores/timeseries.js
+++ b/mdp-webui/src/lib/stores/timeseries.js
@@ -12,7 +12,7 @@ const CLEANUP_INTERVAL = 60000;      // Cleanup old data every minute
 
 // Helper to generate unique session IDs
 function generateSessionId() {
-  return `session-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+  return `session-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
 }
 
 // Initialize the store state


### PR DESCRIPTION
## Summary
- replace usage of `substr` with `slice` when generating session IDs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687311e27f288331b973e4deb275aae4