### PR TITLE
Enable auto-generation of Kaitai parser for WebUI

### DIFF
--- a/mdp-webui/README.md
+++ b/mdp-webui/README.md
@@ -24,12 +24,17 @@ A web-based interface for the Miniware MDP (M01/M02) multi-channel power supply 
 npm install --legacy-peer-deps
 ```
 
-2. Start the development server:
+2. (Optional) Regenerate the Kaitai parser from `cpp/mdp.ksy`:
+```bash
+npm run generate-kaitai
+```
+
+3. Start the development server:
 ```bash
 npm run dev
 ```
 
-3. Open your browser to http://localhost:5173
+4. Open your browser to http://localhost:5173
 
 ## Usage
 

--- a/mdp-webui/package-lock.json
+++ b/mdp-webui/package-lock.json
@@ -20,11 +20,13 @@
         "canvas": "^3.1.2",
         "happy-dom": "^18.0.1",
         "jsdom": "^26.1.0",
+        "kaitai-struct-compiler": "^0.10.0",
         "playwright": "^1.54.0",
         "svelte": "^5.35.2",
         "typescript": "^5.8.3",
         "vite": "^7.0.3",
-        "vitest": "^3.2.4"
+        "vitest": "^3.2.4",
+        "yaml": "^2.8.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -2361,6 +2363,13 @@
       "integrity": "sha512-81oxVi/OY+LrzgrONX7ciD1wtvq24nb2M9iYixRiQG+1hrDrDRqFVWuQzF1fUexh3Sg/ol6eMAz1MOVYFouzUg==",
       "license": "Apache-2.0"
     },
+    "node_modules/kaitai-struct-compiler": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/kaitai-struct-compiler/-/kaitai-struct-compiler-0.10.0.tgz",
+      "integrity": "sha512-zIIGUn6X3UQJ05mwkZ0QUbLTdq9Oopyl9EPSoQHiSpnHFfuQHCphj+doLm6oXD/ouUXpPC860185dGCCzNVi2A==",
+      "dev": true,
+      "license": "GPL-3.0-or-later"
+    },
     "node_modules/kleur": {
       "version": "4.1.5",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
@@ -3905,6 +3914,19 @@
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/yaml": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.0.tgz",
+      "integrity": "sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      }
     },
     "node_modules/zimmerframe": {
       "version": "1.1.2",

--- a/mdp-webui/package.json
+++ b/mdp-webui/package.json
@@ -11,7 +11,9 @@
     "test:ui": "vitest --ui",
     "test:coverage": "vitest --coverage",
     "test:run": "vitest run",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "generate-kaitai": "node scripts/generate-kaitai.cjs",
+    "prebuild": "npm run generate-kaitai"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^6.0.0",
@@ -22,11 +24,13 @@
     "canvas": "^3.1.2",
     "happy-dom": "^18.0.1",
     "jsdom": "^26.1.0",
+    "kaitai-struct-compiler": "^0.10.0",
     "playwright": "^1.54.0",
     "svelte": "^5.35.2",
     "typescript": "^5.8.3",
     "vite": "^7.0.3",
-    "vitest": "^3.2.4"
+    "vitest": "^3.2.4",
+    "yaml": "^2.8.0"
   },
   "dependencies": {
     "kaitai-struct": "^0.10.0",

--- a/mdp-webui/scripts/generate-kaitai.cjs
+++ b/mdp-webui/scripts/generate-kaitai.cjs
@@ -1,0 +1,25 @@
+const fs = require('fs');
+const path = require('path');
+const YAML = require('yaml');
+const KaitaiStructCompiler = require('kaitai-struct-compiler');
+
+async function main() {
+  const ksyPath = path.resolve(__dirname, '..', 'cpp', 'mdp.ksy');
+  const outDir = path.resolve(__dirname, '..', 'src', 'lib', 'kaitai');
+  const ksyYaml = fs.readFileSync(ksyPath, 'utf8');
+  const ksy = YAML.parse(ksyYaml);
+  const compiler = new KaitaiStructCompiler();
+  try {
+    const files = await compiler.compile('javascript', ksy, null, false);
+    if (!fs.existsSync(outDir)) fs.mkdirSync(outDir, { recursive: true });
+    for (const [name, content] of Object.entries(files)) {
+      fs.writeFileSync(path.join(outDir, name), content);
+    }
+    console.log('Generated files:', Object.keys(files).join(', '));
+  } catch (err) {
+    console.error('Failed to generate Kaitai parser:', err);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
## Summary
- generate MiniwareMdpM01.js from `mdp.ksy` before building the web UI
- add script `generate-kaitai.cjs` and dev dependencies
- document optional parser regeneration step in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68731b4410048331b9259aa6723cdb69