### PR TITLE
Remove duplicate machine type mapping

### DIFF
--- a/mdp-webui/src/lib/debug-logger.js
+++ b/mdp-webui/src/lib/debug-logger.js
@@ -1,5 +1,6 @@
 // Debug logging utility with conditional logging and human-readable packet names
 import { writable } from 'svelte/store';
+import { getMachineTypeString } from './machine-utils.js';
 
 // Debug logging enabled state
 export const debugEnabled = writable(true); // Default enabled
@@ -178,14 +179,4 @@ function logAddrData(category, data) {
 function logMachineData(category, data) {
   debugLog(category, `    🏭 MACHINE DATA:`);
   debugLog(category, `      Type: ${data.type} (${getMachineTypeString(data.type)})`);
-}
-
-function getMachineTypeString(type) {
-  const types = {
-    2: 'P906 PSU',
-    3: 'L1060 Load',
-    16: 'M01 with LCD', 
-    17: 'M02 without LCD'
-  };
-  return types[type] || `Unknown (${type})`;
 }

--- a/mdp-webui/src/lib/machine-utils.js
+++ b/mdp-webui/src/lib/machine-utils.js
@@ -1,0 +1,11 @@
+export function getMachineTypeString(type) {
+  const types = {
+    0: 'Node',
+    1: 'P905',
+    2: 'P906',
+    3: 'L1060',
+    16: 'M01 with LCD',
+    17: 'M02 without LCD'
+  };
+  return types[type] || `Unknown (${type})`;
+}

--- a/mdp-webui/src/lib/packet-decoder.js
+++ b/mdp-webui/src/lib/packet-decoder.js
@@ -1,5 +1,6 @@
 import { KaitaiStream, MiniwareMdpM01 } from './kaitai-wrapper.js';
 import { debugLog, debugError, debugWarn, logDecodedKaitaiData, getPacketTypeDisplay, debugEnabled } from './debug-logger.js';
+import { getMachineTypeString } from './machine-utils.js';
 import { get } from 'svelte/store';
 
 export const PackType = MiniwareMdpM01?.PackType || {
@@ -247,15 +248,6 @@ export function processMachinePacket(packet) {
   };
 }
 
-function getMachineTypeString(type) {
-  switch(type) {
-    case 0: return 'Node';
-    case 1: return 'P905';
-    case 2: return 'P906';
-    case 3: return 'L1060';
-    default: return 'Unknown';
-  }
-}
 
 function getOperatingMode(channel) {
   if (channel.type === 3) { // L1060


### PR DESCRIPTION
## Summary
- centralize machine type string conversion in a new helper
- update debug logger and packet decoder to use the helper

## Testing
- `npm test`
- `pytest -q` *(fails: ModuleNotFoundError / AttributeError)*

------
https://chatgpt.com/codex/tasks/task_e_687ae2ac6c14833195c518e97595e70f