### PR TITLE
Fix error handling smell in parser

### DIFF
--- a/py/mdp_m01/parser.py
+++ b/py/mdp_m01/parser.py
@@ -128,4 +128,4 @@ def process_packet(p):
                 )
             )
         return Synthesize(channels=channels)
-    assert ValueError(f"Unknown packet type: {p.pack_type}")
+    raise ValueError(f"Unknown packet type: {p.pack_type}")


### PR DESCRIPTION
## Summary
- replace incorrect `assert ValueError(...)` with an explicit `raise` so unexpected packet types surface properly
- update parser test to call the correct `parse_buffer` helper

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc84c1d5e88331ab5273b34361bd30