### PR TITLE
Fix packet type error handling

### DIFF
--- a/py/mdp_m01/parser.py
+++ b/py/mdp_m01/parser.py
@@ -128,4 +128,4 @@ def process_packet(p):
                 )
             )
         return Synthesize(channels=channels)
-    assert ValueError(f"Unknown packet type: {p.pack_type}")
+    raise ValueError(f"Unknown packet type: {p.pack_type}")


### PR DESCRIPTION
## Summary
- replace an ineffective assert with a proper ValueError when a packet type is unknown

## Testing
- pytest *(fails: ModuleNotFoundError: No module named 'kaitaistruct')*

------
https://chatgpt.com/codex/tasks/task_e_68cfc2194aa88331a76f4f9b877ce37a