### PR TITLE
Fix error handling when encountering unknown packet types

### DIFF
--- a/py/mdp_m01/parser.py
+++ b/py/mdp_m01/parser.py
@@ -128,4 +128,4 @@ def process_packet(p):
                 )
             )
         return Synthesize(channels=channels)
-    assert ValueError(f"Unknown packet type: {p.pack_type}")
+    raise ValueError(f"Unknown packet type: {p.pack_type}")


### PR DESCRIPTION
## Summary
- raise a ValueError for unknown packet types instead of using a no-op assert
- fix the parser test to call the correct buffer parsing helper

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cfc2194aa88331a76f4f9b877ce37a