### PR TITLE
refactor: reuse log prefix constants

### DIFF
--- a/mdp-webui/src/lib/debug-logger.ts
+++ b/mdp-webui/src/lib/debug-logger.ts
@@ -66,20 +66,21 @@ export function debugError(category: string, message: string, ...args: any[]): v
   console.error(prefix + message, ...args);
 }
 
+const LOG_PREFIXES: Readonly<Record<string, string>> = {
+  'raw-serial': '🔴 RAW SERIAL: ',
+  'packet-parse': '🔵 PACKET PARSE: ',
+  'packet-handle': '🟢 PACKET HANDLE: ',
+  'packet-register': '📋 PACKET REGISTER: ',
+  'packet-decode': '🔧 PACKET DECODE: ',
+  'synthesize': '⚙️ SYNTHESIZE: ',
+  'channel-store': '📊 CHANNEL STORE: ',
+  'packet-send': '📤 PACKET SEND: ',
+  'kaitai': '🔬 KAITAI: ',
+  'emergency': '🚨 EMERGENCY: '
+};
+
 function getLogPrefix(category: string): string {
-  const prefixes: Record<string, string> = {
-    'raw-serial': '🔴 RAW SERIAL: ',
-    'packet-parse': '🔵 PACKET PARSE: ',
-    'packet-handle': '🟢 PACKET HANDLE: ',
-    'packet-register': '📋 PACKET REGISTER: ',
-    'packet-decode': '🔧 PACKET DECODE: ',
-    'synthesize': '⚙️ SYNTHESIZE: ',
-    'channel-store': '📊 CHANNEL STORE: ',
-    'packet-send': '📤 PACKET SEND: ',
-    'kaitai': '🔬 KAITAI: ',
-    'emergency': '🚨 EMERGENCY: '
-  };
-  return prefixes[category] || '🔍 DEBUG: ';
+  return LOG_PREFIXES[category] || '🔍 DEBUG: ';
 }
 
 // Enhanced packet data logging


### PR DESCRIPTION
## Summary
- hoist debug log prefix map to a module-level constant so it is reused across calls

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1a53481bc8331817ba9c7ee2c0a5f