### PR TITLE
refactor: centralize debug logging helpers

### DIFF
--- a/mdp-webui/src/lib/debug-logger.ts
+++ b/mdp-webui/src/lib/debug-logger.ts
@@ -45,25 +45,25 @@ debugEnabled.subscribe(value => {
   currentDebugState = value;
 });
 
-export function debugLog(category: string, message: string, ...args: any[]): void {
+type ConsoleMethod = 'log' | 'warn' | 'error';
+
+function writeDebugLog(method: ConsoleMethod, category: string, message: string, ...args: any[]): void {
   if (!currentDebugState) return;
-  
+
   const prefix = getLogPrefix(category);
-  console.log(prefix + message, ...args);
+  console[method](prefix + message, ...args);
+}
+
+export function debugLog(category: string, message: string, ...args: any[]): void {
+  writeDebugLog('log', category, message, ...args);
 }
 
 export function debugWarn(category: string, message: string, ...args: any[]): void {
-  if (!currentDebugState) return;
-  
-  const prefix = getLogPrefix(category);
-  console.warn(prefix + message, ...args);
+  writeDebugLog('warn', category, message, ...args);
 }
 
 export function debugError(category: string, message: string, ...args: any[]): void {
-  if (!currentDebugState) return;
-  
-  const prefix = getLogPrefix(category);
-  console.error(prefix + message, ...args);
+  writeDebugLog('error', category, message, ...args);
 }
 
 const LOG_PREFIXES: Readonly<Record<string, string>> = {


### PR DESCRIPTION
## Summary
- replace the duplicated debug logging functions with a single shared helper to reduce repetition

## Testing
- npm run lint


------
https://chatgpt.com/codex/tasks/task_e_68ed7112233c8331831dd5738abd4294