### PR TITLE
Refactor debug logger to remove duplicated log branches

### DIFF
--- a/mdp-webui/src/lib/debug-logger.ts
+++ b/mdp-webui/src/lib/debug-logger.ts
@@ -45,25 +45,27 @@ debugEnabled.subscribe(value => {
   currentDebugState = value;
 });
 
-export function debugLog(category: string, message: string, ...args: any[]): void {
-  if (!currentDebugState) return;
-  
+type ConsoleLevel = 'log' | 'warn' | 'error';
+
+function logWithLevel(level: ConsoleLevel, category: string, message: string, args: any[]): void {
+  if (!currentDebugState) {
+    return;
+  }
+
   const prefix = getLogPrefix(category);
-  console.log(prefix + message, ...args);
+  console[level](prefix + message, ...args);
+}
+
+export function debugLog(category: string, message: string, ...args: any[]): void {
+  logWithLevel('log', category, message, args);
 }
 
 export function debugWarn(category: string, message: string, ...args: any[]): void {
-  if (!currentDebugState) return;
-  
-  const prefix = getLogPrefix(category);
-  console.warn(prefix + message, ...args);
+  logWithLevel('warn', category, message, args);
 }
 
 export function debugError(category: string, message: string, ...args: any[]): void {
-  if (!currentDebugState) return;
-  
-  const prefix = getLogPrefix(category);
-  console.error(prefix + message, ...args);
+  logWithLevel('error', category, message, args);
 }
 
 const LOG_PREFIXES: Readonly<Record<string, string>> = {


### PR DESCRIPTION
## Summary
- consolidate debug logging to a single helper that routes to log, warn, or error
- reduce repeated console prefix generation across debug logging helpers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68ed7112233c8331831dd5738abd4294