### PR TITLE
refactor: introduce AppRuntime and packet bus

### DIFF
--- a/mdp-webui/src/lib/app/context.ts
+++ b/mdp-webui/src/lib/app/context.ts
@@ -1,0 +1,20 @@
+import { getContext, setContext } from 'svelte';
+import type { AppRuntime } from './runtime';
+
+const RUNTIME_CONTEXT_KEY: unique symbol = Symbol('mdp-webui:runtime');
+
+export function setRuntime(runtime: AppRuntime): void {
+  setContext(RUNTIME_CONTEXT_KEY, runtime);
+}
+
+export function getRuntime(): AppRuntime | undefined {
+  return getContext<AppRuntime | undefined>(RUNTIME_CONTEXT_KEY);
+}
+
+export function useRuntime(): AppRuntime {
+  const runtime = getContext<AppRuntime | undefined>(RUNTIME_CONTEXT_KEY);
+  if (!runtime) {
+    throw new Error('AppRuntime not found in Svelte context');
+  }
+  return runtime;
+}

--- a/mdp-webui/src/lib/app/runtime.ts
+++ b/mdp-webui/src/lib/app/runtime.ts
@@ -1,0 +1,50 @@
+import { SerialConnection } from '../serial';
+import { createPacketBus } from '../services/packet-bus';
+import type { PacketBus } from '../services/packet-bus';
+import { createChannelStore } from '../stores/channels';
+import type { ChannelStore } from '../stores/channels';
+import { createSparklineStore } from '../stores/sparkline';
+import type { SparklineStore } from '../stores/sparkline';
+import { createTimeseriesStore } from '../stores/timeseries';
+import type { TimeseriesStore } from '../stores/timeseries';
+import { createTimeseriesIntegration } from '../stores/timeseries-integration';
+import type { TimeseriesIntegration } from '../stores/timeseries-integration';
+
+export type AppRuntime = {
+  serial: SerialConnection;
+  packets: PacketBus;
+  channels: ChannelStore;
+  sparklines: SparklineStore;
+  timeseries: TimeseriesStore;
+  timeseriesIntegration: TimeseriesIntegration;
+  destroy: () => void;
+};
+
+export function createRuntime(options?: { serial?: SerialConnection }): AppRuntime {
+  const serial = options?.serial ?? new SerialConnection();
+  const packets = createPacketBus(serial);
+
+  packets.start();
+
+  const channels = createChannelStore({ serial, packets });
+  const timeseries = createTimeseriesStore();
+  const sparklines = createSparklineStore({ channels: channels.channels });
+  const timeseriesIntegration = createTimeseriesIntegration({ packets, timeseries, channels });
+
+  const destroy = (): void => {
+    sparklines.destroy();
+    timeseriesIntegration.destroy();
+    channels.destroy();
+    packets.stop();
+  };
+
+  return {
+    serial,
+    packets,
+    channels,
+    sparklines,
+    timeseries,
+    timeseriesIntegration,
+    destroy,
+  };
+}

--- a/mdp-webui/src/lib/components/ChannelCard.svelte
+++ b/mdp-webui/src/lib/components/ChannelCard.svelte
@@ -1,13 +1,25 @@
 <script lang="ts">
   import type { Channel } from '$lib/types';
+  import { getRuntime } from '$lib/app/context';
+  import type { SparklineStore } from '$lib/stores/sparkline';
   import OutputButton from './OutputButton.svelte';
   import Sparkline from './Sparkline.svelte';
   
   export let channel: Channel;
   export let active = false;
   export let onclick: (() => void) | undefined = undefined;
+  export let onToggleOutput: ((channel: number, enabled: boolean) => Promise<void>) | undefined = undefined;
+  export let sparklineStore: SparklineStore | undefined = undefined;
   
   let showModeDetails = false;
+
+  let resolvedOnToggleOutput: ((channel: number, enabled: boolean) => Promise<void>) | undefined = undefined;
+  let resolvedSparklineStore: SparklineStore | undefined = undefined;
+  $: {
+    const runtime = getRuntime();
+    resolvedOnToggleOutput = onToggleOutput ?? runtime?.channels.setOutput;
+    resolvedSparklineStore = sparklineStore ?? runtime?.sparklines;
+  }
   
   function getAvailableModes(machineType: string) {
     if (machineType === 'L1060') {
@@ -67,6 +79,7 @@
             channel={channel.channel} 
             metric="voltage" 
             targetValue={channel.targetVoltage}
+            sparklineStore={resolvedSparklineStore}
             width={80} 
             height={30} 
             showAxes={false}
@@ -83,6 +96,7 @@
             channel={channel.channel} 
             metric="current" 
             targetValue={channel.targetCurrent}
+            sparklineStore={resolvedSparklineStore}
             width={80} 
             height={30} 
             showAxes={false}
@@ -99,6 +113,7 @@
             channel={channel.channel} 
             metric="power" 
             targetValue={channel.targetPower}
+            sparklineStore={resolvedSparklineStore}
             width={80} 
             height={30} 
             showAxes={false}
@@ -126,6 +141,7 @@
         channel={channel.channel}
         isOutput={channel.isOutput}
         machineType={channel.machineType}
+        onToggle={resolvedOnToggleOutput}
         size="small"
       />
     </div>

--- a/mdp-webui/src/lib/components/Dashboard.svelte
+++ b/mdp-webui/src/lib/components/Dashboard.svelte
@@ -1,16 +1,27 @@
 <script lang="ts">
   import type { Readable } from 'svelte/store';
   import type { Channel } from '$lib/types';
-  import { channelStore as defaultChannelStore } from '../stores/channels.js';
+  import type { ChannelStore } from '$lib/stores/channels';
+  import { getRuntime } from '$lib/app/context';
   import ChannelCard from './ChannelCard.svelte';
   
-  export let channelStore = defaultChannelStore;
+  export let channelStore: ChannelStore | undefined = undefined;
   export let onselectchannel: ((_channel: number) => void) | undefined = undefined;
   
   let channels: Readable<Channel[]>;
   let activeChannel: Readable<number>;
+
+  let resolvedChannelStore: ChannelStore;
+  $: {
+    const runtime = getRuntime();
+    const resolved = channelStore ?? runtime?.channels;
+    if (!resolved) {
+      throw new Error('Dashboard requires `channelStore` prop or AppRuntime context');
+    }
+    resolvedChannelStore = resolved;
+  }
   
-  $: ({ channels, activeChannel } = channelStore);
+  $: ({ channels, activeChannel } = resolvedChannelStore);
   
   function selectChannel(channel: number) {
     onselectchannel?.(channel);

--- a/mdp-webui/src/lib/components/OutputButton.svelte
+++ b/mdp-webui/src/lib/components/OutputButton.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-  import { channelStore } from '../stores/channels.js';
   import { createEventDispatcher } from 'svelte';
 
   export let channel: number;
   export let isOutput: boolean;
   export let machineType: string;
+  export let onToggle: ((channel: number, enabled: boolean) => Promise<void>) | undefined = undefined;
   export let disabled = false;
   export let size: 'small' | 'normal' = 'normal';
 
@@ -31,7 +31,7 @@
       event.stopPropagation();
     }
     
-    if (isWaitingForAck || disabled) {
+    if (isWaitingForAck || disabled || !onToggle) {
       return;
     }
 
@@ -54,7 +54,7 @@
     }, 5000);
 
     try {
-      await channelStore.setOutput(channel, newState);
+      await onToggle(channel, newState);
       
       // Success - wait for actual state update to clear optimistic state
       // The actual state will be updated by the synthesize packet handler
@@ -98,7 +98,7 @@
   class:waiting={isWaitingForAck}
   class:small={size === 'small'}
   onpointerup={toggleOutput}
-  {disabled}
+  disabled={disabled || !onToggle}
   type="button"
 >
   {buttonText}: {displayState ? 'ON' : 'OFF'}

--- a/mdp-webui/src/lib/core/signal.ts
+++ b/mdp-webui/src/lib/core/signal.ts
@@ -1,0 +1,25 @@
+export type Unsubscribe = () => void;
+
+export type Signal<T> = {
+  subscribe: (handler: (value: T) => void) => Unsubscribe;
+  emit: (value: T) => void;
+};
+
+export function createSignal<T>(): Signal<T> {
+  const subscribers = new Set<(value: T) => void>();
+
+  return {
+    subscribe(handler) {
+      subscribers.add(handler);
+      return () => {
+        subscribers.delete(handler);
+      };
+    },
+    emit(value) {
+      subscribers.forEach((handler) => {
+        handler(value);
+      });
+    }
+  };
+}
+

--- a/mdp-webui/src/lib/packet-decoder.ts
+++ b/mdp-webui/src/lib/packet-decoder.ts
@@ -4,7 +4,7 @@ import { getMachineTypeString } from './machine-utils';
 import { get } from 'svelte/store';
 import type { DeviceInfo } from './serial.js';
 import type { Channel, WaveformPoint } from './types';
-import type { AddressData, AddressEntry, MachineData, SynthesizeChannel, SynthesizeData, WaveData } from './types/kaitai';
+import type { AddressData, AddressEntry, MachineData, SynthesizeChannel, SynthesizeData, UpdateChannelData, WaveData } from './types/kaitai';
 
 export const PackType = {
   SYNTHESIZE: 0x11,
@@ -29,6 +29,7 @@ export type SynthesizePacket = PacketBase<SynthesizeData> & { packType: typeof P
 export type WavePacket = PacketBase<WaveData> & { packType: typeof PackType.WAVE };
 export type AddressPacket = PacketBase<AddressData> & { packType: typeof PackType.ADDR };
 export type MachinePacket = PacketBase<MachineData> & { packType: typeof PackType.MACHINE };
+export type UpdateChannelPacket = PacketBase<UpdateChannelData> & { packType: typeof PackType.UPDAT_CH };
 
 export type ChannelUpdate = Partial<Channel> & Pick<Channel, 'channel'>;
 
@@ -62,6 +63,12 @@ function isMachineData(data: unknown): data is MachineData {
   return typeof record.machineTypeRaw === 'number';
 }
 
+function isUpdateChannelData(data: unknown): data is UpdateChannelData {
+  if (typeof data !== 'object' || data === null) return false;
+  const record = data as Record<string, unknown>;
+  return typeof record.targetChannel === 'number';
+}
+
 export function isSynthesizePacket(packet: DecodedPacket): packet is SynthesizePacket {
   return packet.packType === PackType.SYNTHESIZE && isSynthesizeData(packet.data);
 }
@@ -76,6 +83,10 @@ export function isAddressPacket(packet: DecodedPacket): packet is AddressPacket 
 
 export function isMachinePacket(packet: DecodedPacket): packet is MachinePacket {
   return packet.packType === PackType.MACHINE && isMachineData(packet.data);
+}
+
+export function isUpdateChannelPacket(packet: DecodedPacket): packet is UpdateChannelPacket {
+  return packet.packType === PackType.UPDAT_CH && isUpdateChannelData(packet.data);
 }
 
 export function decodePacket(data: Uint8Array | number[] | null): DecodedPacket | null {

--- a/mdp-webui/src/lib/services/packet-bus.ts
+++ b/mdp-webui/src/lib/services/packet-bus.ts
@@ -1,0 +1,92 @@
+import { createSignal } from '../core/signal';
+import type { Signal, Unsubscribe } from '../core/signal';
+import { PackType, decodePacket, isAddressPacket, isMachinePacket, isSynthesizePacket, isUpdateChannelPacket, isWavePacket } from '../packet-decoder';
+import type { AddressPacket, DecodedPacket, MachinePacket, SynthesizePacket, UpdateChannelPacket, WavePacket } from '../packet-decoder';
+import type { SerialConnection } from '../serial';
+
+export type PacketBus = {
+  start: () => void;
+  stop: () => void;
+  onRawPacket: Signal<number[]>;
+  onDecodedPacket: Signal<DecodedPacket>;
+  onSynthesize: Signal<SynthesizePacket>;
+  onWave: Signal<WavePacket>;
+  onAddress: Signal<AddressPacket>;
+  onMachine: Signal<MachinePacket>;
+  onUpdateChannel: Signal<UpdateChannelPacket>;
+};
+
+export function createPacketBus(serial: SerialConnection): PacketBus {
+  const onRawPacket = createSignal<number[]>();
+  const onDecodedPacket = createSignal<DecodedPacket>();
+  const onSynthesize = createSignal<SynthesizePacket>();
+  const onWave = createSignal<WavePacket>();
+  const onAddress = createSignal<AddressPacket>();
+  const onMachine = createSignal<MachinePacket>();
+  const onUpdateChannel = createSignal<UpdateChannelPacket>();
+
+  let started = false;
+  let unsubscribes: Unsubscribe[] = [];
+
+  const handlePacket = (packet: number[]): void => {
+    onRawPacket.emit(packet);
+
+    const decoded = decodePacket(packet);
+    if (!decoded) return;
+
+    onDecodedPacket.emit(decoded);
+
+    if (isSynthesizePacket(decoded)) {
+      onSynthesize.emit(decoded);
+      return;
+    }
+    if (isWavePacket(decoded)) {
+      onWave.emit(decoded);
+      return;
+    }
+    if (isAddressPacket(decoded)) {
+      onAddress.emit(decoded);
+      return;
+    }
+    if (isMachinePacket(decoded)) {
+      onMachine.emit(decoded);
+      return;
+    }
+    if (isUpdateChannelPacket(decoded)) {
+      onUpdateChannel.emit(decoded);
+    }
+  };
+
+  const start = (): void => {
+    if (started) return;
+    started = true;
+
+    unsubscribes = [
+      serial.registerPacketHandler(PackType.SYNTHESIZE, handlePacket),
+      serial.registerPacketHandler(PackType.WAVE, handlePacket),
+      serial.registerPacketHandler(PackType.ADDR, handlePacket),
+      serial.registerPacketHandler(PackType.UPDAT_CH, handlePacket),
+      serial.registerPacketHandler(PackType.MACHINE, handlePacket),
+      serial.registerPacketHandler(PackType.ERR_240, handlePacket),
+    ];
+  };
+
+  const stop = (): void => {
+    if (!started) return;
+    started = false;
+    unsubscribes.forEach((unsubscribe) => unsubscribe());
+    unsubscribes = [];
+  };
+
+  return {
+    start,
+    stop,
+    onRawPacket,
+    onDecodedPacket,
+    onSynthesize,
+    onWave,
+    onAddress,
+    onMachine,
+    onUpdateChannel,
+  };
+}

--- a/mdp-webui/src/lib/stores/channels.ts
+++ b/mdp-webui/src/lib/stores/channels.ts
@@ -1,93 +1,101 @@
-import { writable, derived, get } from 'svelte/store';
+import { derived, writable } from 'svelte/store';
+import type { Readable, Writable } from 'svelte/store';
 import type { Channel, WaveformPoint } from '../types';
-import { serialConnection } from '../serial';
-import { decodePacket, isSynthesizePacket, isWavePacket, processSynthesizePacket, processWavePacket, processMachinePacket } from '../packet-decoder';
-import type { ChannelUpdate } from '../packet-decoder';
-import { createSetChannelPacket, createSetVoltagePacket, createSetCurrentPacket, createSetOutputPacket } from '../packet-encoder';
+import { processAddressPacket, processMachinePacket, processSynthesizePacket } from '../packet-decoder';
+import type { AddressPacket, ChannelUpdate, MachinePacket, SynthesizePacket, UpdateChannelPacket, WavePacket } from '../packet-decoder';
+import { createSetChannelPacket, createSetCurrentPacket, createSetOutputPacket, createSetVoltagePacket } from '../packet-encoder';
 import { debugError } from '../debug-logger';
-import { timeseriesStore } from './timeseries';
+import type { PacketBus } from '../services/packet-bus';
+import type { SerialConnection } from '../serial';
 
-const PACKET_TYPES = {
-  SYNTHESIZE: 17,  // 0x11
-  WAVE: 18,        // 0x12
-  ADDR: 19,        // 0x13
-  UPDATE_CH: 20,   // 0x14
-  MACHINE: 21      // 0x15
-};
+export type ChannelStore = ReturnType<typeof createChannelStore>;
 
-export function createChannelStore() {
-  type TimeSeriesPoint = Parameters<typeof timeseriesStore.addDataPoints>[0][number];
-  type FilteredChannel = { channel: number; data: ChannelUpdate; warnings: string[] };
+export function createChannelStore(options: { serial: SerialConnection; packets: PacketBus }): {
+  channels: Writable<Channel[]>;
+  activeChannel: Readable<number>;
+  waitingSynthesize: Readable<boolean>;
+  activeChannelData: Readable<Channel>;
+  recordingChannels: Readable<Channel[]>;
+  setActiveChannel: (channel: number) => Promise<void>;
+  setVoltage: (channel: number, voltage: number, current: number) => Promise<void>;
+  setCurrent: (channel: number, voltage: number, current: number) => Promise<void>;
+  setOutput: (channel: number, enabled: boolean) => Promise<void>;
+  startRecording: (channel: number) => void;
+  stopRecording: (channel: number) => void;
+  clearRecording: (channel: number) => void;
+  reset: () => void;
+  destroy: () => void;
+} {
+  const { serial, packets } = options;
 
-  const getInitialState = (): Channel[] => Array(6).fill(null).map((_, i) => ({
-    channel: i,
-    online: false,
-    machineType: 'Unknown',
-    voltage: 0,
-    current: 0,
-    power: 0,
-    temperature: 0,
-    isOutput: false,
-    mode: 'Normal',
-    address: [0, 0, 0, 0, 0],
-    targetVoltage: 0,
-    targetCurrent: 0,
-    targetPower: 0,
-    recording: false,
-    waveformData: []
-  }));
+  const getInitialState = (): Channel[] =>
+    Array(6)
+      .fill(null)
+      .map((_, i) => ({
+        channel: i,
+        online: false,
+        machineType: 'Unknown',
+        voltage: 0,
+        current: 0,
+        power: 0,
+        temperature: 0,
+        isOutput: false,
+        mode: 'Normal',
+        address: [0, 0, 0, 0, 0],
+        targetVoltage: 0,
+        targetCurrent: 0,
+        targetPower: 0,
+        recording: false,
+        waveformData: [],
+      }));
 
   const channels = writable(getInitialState());
   const activeChannel = writable(0);
   const waitingSynthesize = writable(true);
 
   function markChannelsOffline(): void {
-    channels.update(chs =>
-      chs.map(channel => ({
+    channels.update((chs) =>
+      chs.map((channel) => ({
         ...channel,
         online: false,
         power: 0,
         current: 0,
-        voltage: 0
+        voltage: 0,
       }))
     );
   }
 
-  // Channel validation functions
   function validateChannelData(channelData: ChannelUpdate): { isValid: boolean; warnings: string[] } {
     const warnings: string[] = [];
     let isValid = true;
 
-    // Validate online flag (accept boolean or 0/1)
     if (typeof channelData.online === 'boolean') {
-      // Boolean values are valid
+      // ok
     } else if (channelData.online !== 0 && channelData.online !== 1) {
       warnings.push(`Invalid online flag: ${channelData.online} (should be 0, 1, true, or false)`);
       isValid = false;
     }
 
-    // Validate temperature range (reasonable for electronics: -10°C to 85°C)
     const temperature = typeof channelData.temperature === 'number' ? channelData.temperature : Number.NaN;
     if (!Number.isFinite(temperature) || temperature < -10 || temperature > 85) {
-      warnings.push(`Temperature out of range: ${Number.isFinite(temperature) ? temperature.toFixed(1) : 'NaN'}°C (should be -10°C to 85°C)`);
+      warnings.push(
+        `Temperature out of range: ${Number.isFinite(temperature) ? temperature.toFixed(1) : 'NaN'}°C (should be -10°C to 85°C)`
+      );
       isValid = false;
     }
 
-    // Validate voltage range (0-50V reasonable for these devices)
     const voltage = typeof channelData.voltage === 'number' ? channelData.voltage : Number.NaN;
     if (!Number.isFinite(voltage) || voltage < 0 || voltage > 50) {
       warnings.push(`Voltage out of range: ${Number.isFinite(voltage) ? voltage.toFixed(3) : 'NaN'}V (should be 0V to 50V)`);
       isValid = false;
     }
 
-    // Validate current range (0-10A reasonable for these devices)
     const current = typeof channelData.current === 'number' ? channelData.current : Number.NaN;
     if (!Number.isFinite(current) || current < 0 || current > 10) {
       warnings.push(`Current out of range: ${Number.isFinite(current) ? current.toFixed(3) : 'NaN'}A (should be 0A to 10A)`);
       isValid = false;
     }
 
-    // Validate machine type
     const validTypes = ['Node', 'P905', 'P906', 'L1060', 'Unknown'];
     if (typeof channelData.machineType !== 'string' || !validTypes.includes(channelData.machineType)) {
       warnings.push(`Invalid machine type: ${String(channelData.machineType)}`);
@@ -97,210 +105,106 @@ export function createChannelStore() {
     return { isValid, warnings };
   }
 
-  // Register packet handlers
-  function synthesizeHandler(packet: number[]): void {
-    const decoded = decodePacket(packet);
-    
-    if (!decoded) {
-      debugError('channel-store', 'Decoding failed for SYNTHESIZE packet');
+  function mergeChannelUpdate(chs: Channel[], index: number, update: ChannelUpdate): void {
+    const previous = chs[index];
+    const validation = validateChannelData(update);
+    const channelData = validation.isValid ? update : { ...update, online: false };
+    chs[index] = { ...previous, ...channelData, waveformData: previous.waveformData };
+  }
+
+  function handleSynthesize(packet: SynthesizePacket): void {
+    const processed = processSynthesizePacket(packet);
+    if (!processed) {
+      debugError('channel-store', 'Processing failed for SYNTHESIZE packet');
       markChannelsOffline();
       waitingSynthesize.set(false);
       return;
     }
 
-	    const processed = processSynthesizePacket(decoded);
-
-	    if (processed) {
-	      // Validate and filter channels
-	      const validatedChannels: ChannelUpdate[] = [];
-	      const filteredChannels: FilteredChannel[] = [];
-	      let totalWarnings = 0;
-
-      // console.log('🔍 CHANNEL VALIDATION ANALYSIS:');
-      
-	      processed.forEach((channelData, i: number) => {
-	        const validation = validateChannelData(channelData);
-	        
-	        if (validation.isValid && Boolean(channelData.online)) {
-	          validatedChannels.push(channelData);
-	          // console.log(`✅ Channel ${i}: VALID and ONLINE`);
-	        } else if (!validation.isValid) {
-	          filteredChannels.push({ channel: i, data: channelData, warnings: validation.warnings });
-	          totalWarnings += validation.warnings.length;
-          
-          console.log(`❌ Channel ${i}: FILTERED (${validation.warnings.length} issues)`);
-          validation.warnings.forEach(warning => {
-            console.log(`   ⚠️  ${warning}`);
-	          });
-	          
-	          // Show the problematic raw data for this channel
-	          if (isSynthesizePacket(decoded) && decoded.data.channels[i]) {
-	            const rawCh = decoded.data.channels[i];
-	            console.log(`   📊 Raw channel data:`, {
-	              num: rawCh.num,
-	              online: rawCh.online,
-	              type: rawCh.type,
-              outVoltageRaw: rawCh.outVoltageRaw,
-              outCurrentRaw: rawCh.outCurrentRaw,
-              tempRaw: rawCh.tempRaw,
-              temperature: rawCh.temperature,
-              outputOn: rawCh.outputOn
-            });
-          }
-        } else {
-          // console.log(`ℹ️  Channel ${i}: VALID but OFFLINE`);
-        }
+    channels.update((chs) => {
+      processed.forEach((data, i) => {
+        mergeChannelUpdate(chs, i, data);
       });
+      return chs;
+    });
 
-      const validOnlineCount = validatedChannels.length;
-      
-      // Only show debug output if there are filtered channels
-	      if (filteredChannels.length > 0) {
-        console.log(`\n📊 VALIDATION SUMMARY:`);
-        console.log(`   Valid online channels: ${validOnlineCount}`);
-        console.log(`   Filtered channels: ${filteredChannels.length}`);
-        console.log(`   Total warnings: ${totalWarnings}`);
-        
-	        console.log(`\n🚨 FILTERED CHANNEL BREAKDOWN:`);
-	        filteredChannels.forEach((filtered) => {
-	          const voltage = typeof filtered.data.voltage === 'number' ? filtered.data.voltage.toFixed(3) : 'NaN';
-	          const current = typeof filtered.data.current === 'number' ? filtered.data.current.toFixed(3) : 'NaN';
-	          const temperature = typeof filtered.data.temperature === 'number' ? filtered.data.temperature.toFixed(1) : 'NaN';
-	          console.log(`   Channel ${filtered.channel}: ${filtered.data.machineType}, ${voltage}V, ${current}A, ${temperature}°C`);
-	          console.log(`     Issues: ${filtered.warnings.join(', ')}`);
-	        });
-	      }
-	      
-	      // Update store with all processed channels (including filtered ones as offline)
-	      channels.update(chs => {
-	        processed.forEach((data, i: number) => {
-	          // If channel was filtered, mark it as offline regardless of original online status
-	          const validation = validateChannelData(data);
-	          const channelData = validation.isValid ? data : { ...data, online: false };
-          
-          chs[i] = { ...chs[i], ...channelData, waveformData: chs[i].waveformData };
-        });
-        return chs;
-      });
-      
-      waitingSynthesize.set(false);
-    } else {
-      debugError('channel-store', 'Processing failed for SYNTHESIZE packet');
-      markChannelsOffline();
-      waitingSynthesize.set(false);
-    }
+    waitingSynthesize.set(false);
   }
 
-  function waveHandler(packet: number[]): void {
-    const decoded = decodePacket(packet);
-    if (!decoded) return;
+  function handleWave(packet: WavePacket): void {
+    const channel = packet.data.channel;
 
-	    const processed = processWavePacket(decoded);
-	    
-	    if (processed && processed.points.length > 0 && isWavePacket(decoded)) {
-	      channels.update(chs => {
-	        const ch = chs[processed.channel];
-	        if (ch && ch.recording) {
-          // Initialize running time if this is the first data for this channel
-          if (!ch.runningTimeUs) {
-            ch.runningTimeUs = 0;
-          }
-          
-          // Determine group size from packet length
-          // 126 bytes = 2 samples per group, 206 bytes = 4 samples per group
-          const packetLength = packet.length;
-          const samplesPerGroup = packetLength === 126 ? 2 : 4;
-          
-	          // Process each group's worth of points
-	          let currentPointIndex = 0;
-	          const wave = decoded.data;
-	          
-	          wave.groups.forEach((group) => {
-	            // Convert timestamp from 0.1µs (100ns) ticks to microseconds
-	            const groupElapsedTimeUs = group.timestamp / 10;
-            
-            // Time per sample in this group
-            const timePerSampleUs = groupElapsedTimeUs / samplesPerGroup;
-            
-            // Process each sample in this group
-            for (let i = 0; i < samplesPerGroup && currentPointIndex < processed.points.length; i++) {
-              const point = processed.points[currentPointIndex];
-              
-              // Calculate absolute time for this sample
-              const sampleTimeUs = (ch.runningTimeUs || 0) + (i * timePerSampleUs);
-              
-              if (ch.waveformData) {
-                ch.waveformData.push({
-                  timestamp: sampleTimeUs / 1000, // Convert to milliseconds for display
-                  voltage: point.voltage,
-                  current: point.current
-                });
-              }
-              
-              currentPointIndex++;
-            }
-            
-            // Update running time for next group
-            ch.runningTimeUs = (ch.runningTimeUs || 0) + groupElapsedTimeUs;
+    channels.update((chs) => {
+      const ch = chs[channel];
+      if (!ch || !ch.recording) return chs;
+
+      if (!ch.runningTimeUs) {
+        ch.runningTimeUs = 0;
+      }
+
+      const samplesPerGroup = packet.size === 126 ? 2 : 4;
+      const newPoints: WaveformPoint[] = [];
+
+      packet.data.groups.forEach((group) => {
+        const groupElapsedTimeUs = group.timestamp / 10;
+        const timePerSampleUs = groupElapsedTimeUs / samplesPerGroup;
+
+        for (let i = 0; i < samplesPerGroup; i++) {
+          const item = group.items[i];
+          if (!item) break;
+
+          const sampleTimeUs = (ch.runningTimeUs || 0) + i * timePerSampleUs;
+          newPoints.push({
+            timestamp: sampleTimeUs / 1000,
+            voltage: item.voltage,
+            current: item.current,
           });
         }
-        return chs;
+
+        ch.runningTimeUs = (ch.runningTimeUs || 0) + groupElapsedTimeUs;
       });
-      
-	      // Also update timeseries store with proper timestamps
-	      if (get(channels)[processed.channel]?.recording) {
-	        const ch = get(channels)[processed.channel];
-	        const recentPoints: WaveformPoint[] = ch.waveformData ? ch.waveformData.slice(-processed.points.length) : [];
-	        
-	        const timeseriesPoints: TimeSeriesPoint[] = recentPoints.map((point) => ({
-	          channel: processed.channel,
-	          timestamp: point.timestamp,
-	          data: {
-	            voltage: point.voltage,
-            current: point.current
-          }
-        }));
-        
-        timeseriesStore.addDataPoints(timeseriesPoints);
+
+      if (!ch.waveformData) {
+        ch.waveformData = [];
       }
-    }
+      ch.waveformData.push(...newPoints);
+
+      return chs;
+    });
   }
 
-  function updateChannelHandler(packet: number[]): void {
-    const decoded = decodePacket(packet);
-    if (!decoded) return;
-    
-    if (packet.length >= 7) {
-      const channel = packet[6];
-      activeChannel.set(channel);
-    }
+  function handleUpdateChannel(packet: UpdateChannelPacket): void {
+    activeChannel.set(packet.data.targetChannel);
   }
 
-  function addrHandler(packet: number[]): void {
-    const decoded = decodePacket(packet);
-    if (!decoded) return;
-    
-    // Process address packet if needed
-    // For now just decode it to see the data
+  function handleAddress(packet: AddressPacket): void {
+    const processed = processAddressPacket(packet);
+    if (!processed) return;
+
+    channels.update((chs) => {
+      processed.forEach((entry) => {
+        const previous = chs[entry.channel];
+        if (!previous) return;
+        chs[entry.channel] = { ...previous, address: entry.address };
+      });
+      return chs;
+    });
   }
 
-  function machineHandler(packet: number[]): void {
-    const decoded = decodePacket(packet);
-    if (!decoded) return;
-    
-    const processed = processMachinePacket(decoded);
-    
+  function handleMachine(packet: MachinePacket): void {
+    const processed = processMachinePacket(packet);
     if (processed) {
-      serialConnection.setDeviceType(processed);
+      serial.setDeviceType(processed);
     }
   }
 
-  // Register packet handlers
-  serialConnection.registerPacketHandler(PACKET_TYPES.SYNTHESIZE, synthesizeHandler);
-  serialConnection.registerPacketHandler(PACKET_TYPES.WAVE, waveHandler);
-  serialConnection.registerPacketHandler(PACKET_TYPES.ADDR, addrHandler);
-  serialConnection.registerPacketHandler(PACKET_TYPES.UPDATE_CH, updateChannelHandler);
-  serialConnection.registerPacketHandler(PACKET_TYPES.MACHINE, machineHandler);
+  const unsubscribes = [
+    packets.onSynthesize.subscribe(handleSynthesize),
+    packets.onWave.subscribe(handleWave),
+    packets.onUpdateChannel.subscribe(handleUpdateChannel),
+    packets.onAddress.subscribe(handleAddress),
+    packets.onMachine.subscribe(handleMachine),
+  ];
 
   function updateTargetValues(chs: Channel[], channel: number, voltage: number, current: number): void {
     chs[channel].targetVoltage = voltage;
@@ -310,15 +214,15 @@ export function createChannelStore() {
 
   async function setActiveChannel(channel: number): Promise<void> {
     const packet = createSetChannelPacket(channel);
-    await serialConnection.sendPacket(packet);
+    await serial.sendPacket(packet);
     activeChannel.set(channel);
   }
 
   async function setVoltage(channel: number, voltage: number, current: number): Promise<void> {
     const packet = createSetVoltagePacket(channel, voltage, current);
-    await serialConnection.sendPacket(packet);
+    await serial.sendPacket(packet);
 
-    channels.update(chs => {
+    channels.update((chs) => {
       updateTargetValues(chs, channel, voltage, current);
       return chs;
     });
@@ -326,9 +230,9 @@ export function createChannelStore() {
 
   async function setCurrent(channel: number, voltage: number, current: number): Promise<void> {
     const packet = createSetCurrentPacket(channel, voltage, current);
-    await serialConnection.sendPacket(packet);
+    await serial.sendPacket(packet);
 
-    channels.update(chs => {
+    channels.update((chs) => {
       updateTargetValues(chs, channel, voltage, current);
       return chs;
     });
@@ -336,51 +240,49 @@ export function createChannelStore() {
 
   async function setOutput(channel: number, enabled: boolean): Promise<void> {
     const packet = createSetOutputPacket(channel, enabled);
-    await serialConnection.sendPacket(packet);
+    await serial.sendPacket(packet);
   }
 
   function startRecording(channel: number): void {
-    channels.update(chs => {
+    channels.update((chs) => {
       chs[channel].recording = true;
       chs[channel].waveformData = [];
-      chs[channel].runningTimeUs = 0; // Reset the running time counter
+      chs[channel].runningTimeUs = 0;
       return chs;
     });
   }
 
   function stopRecording(channel: number): void {
-    channels.update(chs => {
+    channels.update((chs) => {
       chs[channel].recording = false;
       return chs;
     });
   }
 
   function clearRecording(channel: number): void {
-    channels.update(chs => {
+    channels.update((chs) => {
       chs[channel].waveformData = [];
       return chs;
     });
   }
 
-  function reset() {
+  function reset(): void {
     channels.set(getInitialState());
     activeChannel.set(0);
     waitingSynthesize.set(true);
   }
 
-  const activeChannelData = derived(
-    [channels, activeChannel],
-    ([$channels, $activeChannel]) => $channels[$activeChannel]
-  );
+  const activeChannelData = derived([channels, activeChannel], ([$channels, $activeChannel]) => $channels[$activeChannel]);
+  const recordingChannels = derived(channels, ($channels) => $channels.filter((ch) => ch.recording));
 
-  const recordingChannels = derived(channels, ($channels) =>
-    $channels.filter((ch) => ch.recording)
-  );
+  function destroy(): void {
+    unsubscribes.forEach((unsubscribe) => unsubscribe());
+  }
 
   return {
     channels,
-    activeChannel: derived(activeChannel, $active => $active),
-    waitingSynthesize: derived(waitingSynthesize, $waiting => $waiting),
+    activeChannel: derived(activeChannel, ($active) => $active),
+    waitingSynthesize: derived(waitingSynthesize, ($waiting) => $waiting),
     activeChannelData,
     recordingChannels,
     setActiveChannel,
@@ -390,8 +292,7 @@ export function createChannelStore() {
     startRecording,
     stopRecording,
     clearRecording,
-    reset
+    reset,
+    destroy,
   };
 }
-
-export const channelStore = createChannelStore();

--- a/mdp-webui/src/lib/stores/timeseries-integration.ts
+++ b/mdp-webui/src/lib/stores/timeseries-integration.ts
@@ -1,262 +1,49 @@
 /**
- * Integration module for timeseries store with packet handlers
- * This shows how to connect the timeseries store to the existing packet processing
+ * Integration module for timeseries store with packet bus.
+ * Connects decoded packets to timeseries recording and export utilities.
  */
 
-import { timeseriesStore } from './timeseries.js';
-import { channelStore } from './channels.js';
-import { serialConnection } from '../serial.js';
 import { get } from 'svelte/store';
-
-type TimeSeriesPoint = Parameters<typeof timeseriesStore.addDataPoints>[0][number];
-type SynthesizeChannel = NonNullable<ReturnType<ReturnType<typeof serialConnection.getDecoder>['decodeSynthesize']>>['data']['channels'][number];
+import type { SynthesizeChannel } from '../types/kaitai';
+import type { PacketBus } from '../services/packet-bus';
+import type { ChannelStore } from './channels';
+import type { TimeseriesStore, TimeSeriesPoint } from './timeseries';
 
 function getOperatingMode(channel: SynthesizeChannel): string {
   // L1060
   if (channel.type === 3) {
     switch (channel.statusLoad) {
-      case 0: return 'CC';
-      case 1: return 'CV';
-      case 2: return 'CR';
-      case 3: return 'CP';
-      default: return 'Normal';
+      case 0:
+        return 'CC';
+      case 1:
+        return 'CV';
+      case 2:
+        return 'CR';
+      case 3:
+        return 'CP';
+      default:
+        return 'Normal';
     }
   }
 
   // P906
   if (channel.type === 2) {
     switch (channel.statusPsu) {
-      case 1: return 'CC';
-      case 2: return 'CV';
-      default: return 'Normal';
+      case 1:
+        return 'CC';
+      case 2:
+        return 'CV';
+      default:
+        return 'Normal';
     }
   }
 
   return 'Normal';
 }
 
-/**
- * Initialize timeseries integration with packet handlers
- */
-export function initializeTimeseriesIntegration() {
-  // Register synthesize packet handler for timeseries logging
-  serialConnection.registerPacketHandler(0x11, (packet: number[]) => {
-    const activeSession = get(timeseriesStore.activeSession);
-    if (!activeSession) return;
-    
-    // Process synthesize packet data
-    const decoder = serialConnection.getDecoder();
-    const parsedData = decoder.decodeSynthesize(packet);
-    if (!parsedData) return;
-    
-    const timestamp = Date.now();
-    const points: TimeSeriesPoint[] = [];
-    
-    parsedData.data.channels.forEach((channelData, index: number) => {
-      // Only record channels that are in the active session
-      if (activeSession.channels.has(index)) {
-        points.push({
-          channel: index,
-          timestamp,
-          data: {
-            voltage: channelData.outVoltage,
-            current: channelData.outCurrent,
-            temperature: channelData.temperature,
-            mode: getOperatingMode(channelData),
-            isOutput: channelData.outputOn !== 0
-          }
-        });
-      }
-    });
-    
-    // Add all points in batch for efficiency
-    if (points.length > 0) {
-      timeseriesStore.addDataPoints(points);
-    }
-  });
-  
-  // Register wave packet handler for high-frequency data
-  serialConnection.registerPacketHandler(0x12, (packet: number[]) => {
-    const activeSession = get(timeseriesStore.activeSession);
-    if (!activeSession) return;
-    
-    // Get the channel from packet header
-    const channel = packet[4];
-    if (!activeSession.channels.has(channel)) return;
-    
-    // Process wave packet data
-    const decoder = serialConnection.getDecoder();
-    const parsedData = decoder.decodeWave(packet);
-    if (!parsedData) return;
-    
-    const points: TimeSeriesPoint[] = [];
-    
-    parsedData.data.groups.forEach((group) => {
-      group.items.forEach((item, index: number) => {
-        points.push({
-          channel,
-          timestamp: group.timestamp + index * 10, // 10ms between points
-          data: {
-            voltage: item.voltage,
-            current: item.current
-          }
-        });
-      });
-    });
-    
-    // Add all points in batch
-    if (points.length > 0) {
-      timeseriesStore.addDataPoints(points);
-    }
-  });
-}
-
-/**
- * Start a new recording session for specified channels
- * @param {Array<number>} channels - Channel numbers to record
- * @returns {string} Session ID
- */
-export function startRecording(channels: number[]): string {
-  // Create new session
-  const sessionId = timeseriesStore.createSession(channels);
-  
-  // Update channel store recording state
-  channels.forEach((channel: number) => {
-    channelStore.startRecording(channel);
-  });
-  
-  return sessionId;
-}
-
-/**
- * Stop the current recording session
- */
-export function stopRecording() {
-  const activeSession = get(timeseriesStore.activeSession);
-  if (!activeSession) return;
-  
-  // Update channel store recording state
-  const channelData = get(channelStore.channels);
-  channelData.forEach((ch, index) => {
-    if (ch.recording) {
-      channelStore.stopRecording(index);
-    }
-  });
-  
-  // Close the session
-  timeseriesStore.closeSession(activeSession.id);
-}
-
-/**
- * Export session data to CSV format
- * @param {string} sessionId - Session ID to export
- * @param {Array<number>} channels - Channels to include (null for all)
- * @returns {string} CSV data
- */
-export function exportSessionToCSV(sessionId: string | null = null, channels: number[] | null = null): string {
-  const targetSessionId = sessionId || get(timeseriesStore.activeSession)?.id;
-  if (!targetSessionId) return '';
-  
-  const sessions = get(timeseriesStore.sessionList);
-  const session = sessions.find(s => s.id === targetSessionId);
-  if (!session) return '';
-  
-  // Get all data for the session
-  const data = timeseriesStore.getDataRange(
-    session.metadata.minTimestamp || session.startTime,
-    session.metadata.maxTimestamp || Date.now(),
-    channels,
-    targetSessionId
-  );
-  
-  if (data.length === 0) return '';
-  
-  // Build CSV header
-  const channelsToExport = channels || Array.from(session.channels);
-  const headers = ['Timestamp (ms)', 'Time (s)'];
-  channelsToExport.forEach(ch => {
-    headers.push(`Ch${ch} Voltage (V)`, `Ch${ch} Current (A)`, `Ch${ch} Power (W)`);
-  });
-  
-  // Build CSV rows
-  const rows = [headers.join(',')];
-  const startTime = data[0].timestamp;
-  
-  data.forEach(point => {
-    const row = [
-      point.timestamp,
-      ((point.timestamp - startTime) / 1000).toFixed(3)
-    ];
-    
-    channelsToExport.forEach(ch => {
-      const chData = point.data[`ch${ch}`];
-      if (chData) {
-        row.push(
-          chData.voltage?.toFixed(3) || '',
-          chData.current?.toFixed(3) || '',
-          chData.power?.toFixed(3) || ''
-        );
-      } else {
-        row.push('', '', '');
-      }
-    });
-    
-    rows.push(row.join(','));
-  });
-  
-  return rows.join('\n');
-}
-
-/**
- * Get real-time chart data for active session
- * @param {number} channel - Channel number
- * @param {number} duration - Duration in milliseconds to retrieve
- * @returns {Object} Chart data with timestamps and values
- */
-export function getChartData(channel: number, duration: number = 10000): {timestamps: number[], voltage: number[], current: number[], power: number[]} {
-  const activeSession = get(timeseriesStore.activeSession);
-  if (!activeSession || !activeSession.channels.has(channel)) {
-    return { timestamps: [], voltage: [], current: [], power: [] };
-  }
-  
-  const endTime = Date.now();
-  const startTime = endTime - duration;
-  
-  const data = timeseriesStore.getDataRange(startTime, endTime, [channel]);
-  
-  const result: {
-    timestamps: number[],
-    voltage: number[],
-    current: number[],
-    power: number[]
-  } = {
-    timestamps: [],
-    voltage: [],
-    current: [],
-    power: []
-  };
-  
-  data.forEach(point => {
-    const chData = point.data[`ch${channel}`];
-    if (chData) {
-      result.timestamps.push(point.timestamp);
-      result.voltage.push(chData.voltage || 0);
-      result.current.push(chData.current || 0);
-      result.power.push(chData.power || 0);
-    }
-  });
-  
-  return result;
-}
-
-/**
- * Get session statistics
- * @param {string} sessionId - Session ID (null for active)
- * @returns {Object} Statistics object
- */
 type MetricStats = { min: number; max: number; avg: number };
 type ChannelStats = { voltage: MetricStats; current: MetricStats; power: MetricStats; sampleCount: number };
-type SessionStats = {
+export type SessionStats = {
   sessionId: string;
   startTime: number;
   endTime: number | null;
@@ -267,88 +54,258 @@ type SessionStats = {
   channelStats: Record<number, ChannelStats>;
 };
 
-export function getSessionStats(sessionId: string | null = null): SessionStats | null {
-  const targetSessionId = sessionId || get(timeseriesStore.activeSession)?.id;
-  if (!targetSessionId) return null;
-  
-  const sessions = get(timeseriesStore.sessionList);
-  const session = sessions.find(s => s.id === targetSessionId);
-  if (!session) return null;
-  
-  const stats: SessionStats = {
-    sessionId: session.id,
-    startTime: session.startTime,
-    endTime: session.endTime,
-    duration: (session.endTime || Date.now()) - session.startTime,
-    channels: Array.from(session.channels),
-    pointCount: session.pointCount,
-    sampleRate: session.metadata.sampleRate,
-    channelStats: {}
-  };
-  
-  // Calculate per-channel statistics
-  const data = timeseriesStore.getDataRange(
-    session.metadata.minTimestamp || session.startTime,
-    session.metadata.maxTimestamp || Date.now(),
-    null,
-    targetSessionId
-  );
-  
-  // Initialize channel stats
-  stats.channels.forEach((ch: number) => {
-    stats.channelStats[ch] = {
-      voltage: { min: Infinity, max: -Infinity, avg: 0 },
-      current: { min: Infinity, max: -Infinity, avg: 0 },
-      power: { min: Infinity, max: -Infinity, avg: 0 },
-      sampleCount: 0
-    };
-  });
-  
-  // Calculate statistics
-  data.forEach(point => {
-    stats.channels.forEach((ch: number) => {
-      const chData = point.data[`ch${ch}`];
-      if (chData) {
-        const chStats = stats.channelStats[ch];
-        
-        // Voltage stats
-        if (chData.voltage !== undefined) {
-          chStats.voltage.min = Math.min(chStats.voltage.min, chData.voltage);
-          chStats.voltage.max = Math.max(chStats.voltage.max, chData.voltage);
-          chStats.voltage.avg += chData.voltage;
-        }
-        
-        // Current stats
-        if (chData.current !== undefined) {
-          chStats.current.min = Math.min(chStats.current.min, chData.current);
-          chStats.current.max = Math.max(chStats.current.max, chData.current);
-          chStats.current.avg += chData.current;
-        }
-        
-        // Power stats
-        if (chData.power !== undefined) {
-          chStats.power.min = Math.min(chStats.power.min, chData.power);
-          chStats.power.max = Math.max(chStats.power.max, chData.power);
-          chStats.power.avg += chData.power;
-        }
-        
-        chStats.sampleCount++;
+export type TimeseriesIntegration = ReturnType<typeof createTimeseriesIntegration>;
+
+export function createTimeseriesIntegration(options: {
+  packets: PacketBus;
+  timeseries: TimeseriesStore;
+  channels: ChannelStore;
+}): {
+  startRecording: (channels: number[]) => string;
+  stopRecording: () => void;
+  exportSessionToCSV: (sessionId?: string | null, channels?: number[] | null) => string;
+  getChartData: (
+    channel: number,
+    duration?: number
+  ) => { timestamps: number[]; voltage: number[]; current: number[]; power: number[] };
+  getSessionStats: (sessionId?: string | null) => SessionStats | null;
+  destroy: () => void;
+} {
+  const { packets, timeseries, channels } = options;
+
+  const unsubscribes = [
+    packets.onSynthesize.subscribe((packet) => {
+      const activeSession = get(timeseries.activeSession);
+      if (!activeSession) return;
+
+      const timestamp = Date.now();
+      const points: TimeSeriesPoint[] = [];
+
+      packet.data.channels.forEach((channelData, index: number) => {
+        if (!activeSession.channels.has(index)) return;
+        points.push({
+          channel: index,
+          timestamp,
+          data: {
+            voltage: channelData.outVoltage,
+            current: channelData.outCurrent,
+            temperature: channelData.temperature,
+            mode: getOperatingMode(channelData),
+            isOutput: channelData.outputOn !== 0,
+          },
+        });
+      });
+
+      if (points.length > 0) {
+        timeseries.addDataPoints(points);
+      }
+    }),
+
+    packets.onWave.subscribe((packet) => {
+      const activeSession = get(timeseries.activeSession);
+      if (!activeSession) return;
+
+      const channel = packet.data.channel;
+      if (!activeSession.channels.has(channel)) return;
+
+      const points: TimeSeriesPoint[] = [];
+
+      packet.data.groups.forEach((group) => {
+        group.items.forEach((item, index: number) => {
+          points.push({
+            channel,
+            timestamp: group.timestamp + index * 10,
+            data: {
+              voltage: item.voltage,
+              current: item.current,
+            },
+          });
+        });
+      });
+
+      if (points.length > 0) {
+        timeseries.addDataPoints(points);
+      }
+    }),
+  ];
+
+  function startRecording(channelList: number[]): string {
+    const sessionId = timeseries.createSession(channelList);
+    channelList.forEach((channel) => {
+      channels.startRecording(channel);
+    });
+    return sessionId;
+  }
+
+  function stopRecording(): void {
+    const activeSession = get(timeseries.activeSession);
+    if (!activeSession) return;
+
+    const channelData = get(channels.channels);
+    channelData.forEach((ch, index) => {
+      if (ch.recording) {
+        channels.stopRecording(index);
       }
     });
-  });
-  
-  // Calculate averages
-  stats.channels.forEach((ch: number) => {
-    const chStats = stats.channelStats[ch];
-    if (chStats.sampleCount > 0) {
-      chStats.voltage.avg /= chStats.sampleCount;
-      chStats.current.avg /= chStats.sampleCount;
-      chStats.power.avg /= chStats.sampleCount;
-    }
-  });
-  
-  return stats;
-}
 
-// Consumers must explicitly initialize integration
-// e.g. call initializeTimeseriesIntegration() in the application entry point
+    timeseries.closeSession(activeSession.id);
+  }
+
+  function exportSessionToCSV(sessionId: string | null = null, channelsToExport: number[] | null = null): string {
+    const targetSessionId = sessionId || get(timeseries.activeSession)?.id;
+    if (!targetSessionId) return '';
+
+    const sessions = get(timeseries.sessionList);
+    const session = sessions.find((s) => s.id === targetSessionId);
+    if (!session) return '';
+
+    const data = timeseries.getDataRange(
+      session.metadata.minTimestamp || session.startTime,
+      session.metadata.maxTimestamp || Date.now(),
+      channelsToExport,
+      targetSessionId
+    );
+
+    if (data.length === 0) return '';
+
+    const channelsForHeader = channelsToExport || Array.from(session.channels);
+    const headers = ['Timestamp (ms)', 'Time (s)'];
+    channelsForHeader.forEach((ch) => {
+      headers.push(`Ch${ch} Voltage (V)`, `Ch${ch} Current (A)`, `Ch${ch} Power (W)`);
+    });
+
+    const rows = [headers.join(',')];
+    const startTime = data[0].timestamp;
+
+    data.forEach((point) => {
+      const row: Array<string | number> = [point.timestamp, ((point.timestamp - startTime) / 1000).toFixed(3)];
+
+      channelsForHeader.forEach((ch) => {
+        const chData = point.data[`ch${ch}`];
+        if (chData) {
+          row.push(chData.voltage?.toFixed(3) || '', chData.current?.toFixed(3) || '', chData.power?.toFixed(3) || '');
+        } else {
+          row.push('', '', '');
+        }
+      });
+
+      rows.push(row.join(','));
+    });
+
+    return rows.join('\n');
+  }
+
+  function getChartData(
+    channel: number,
+    duration: number = 10000
+  ): { timestamps: number[]; voltage: number[]; current: number[]; power: number[] } {
+    const activeSession = get(timeseries.activeSession);
+    if (!activeSession || !activeSession.channels.has(channel)) {
+      return { timestamps: [], voltage: [], current: [], power: [] };
+    }
+
+    const endTime = Date.now();
+    const startTime = endTime - duration;
+    const data = timeseries.getDataRange(startTime, endTime, [channel]);
+
+    const result = {
+      timestamps: [] as number[],
+      voltage: [] as number[],
+      current: [] as number[],
+      power: [] as number[],
+    };
+
+    data.forEach((point) => {
+      const chData = point.data[`ch${channel}`];
+      if (!chData) return;
+      result.timestamps.push(point.timestamp);
+      result.voltage.push(chData.voltage || 0);
+      result.current.push(chData.current || 0);
+      result.power.push(chData.power || 0);
+    });
+
+    return result;
+  }
+
+  function getSessionStats(sessionId: string | null = null): SessionStats | null {
+    const targetSessionId = sessionId || get(timeseries.activeSession)?.id;
+    if (!targetSessionId) return null;
+
+    const sessions = get(timeseries.sessionList);
+    const session = sessions.find((s) => s.id === targetSessionId);
+    if (!session) return null;
+
+    const stats: SessionStats = {
+      sessionId: session.id,
+      startTime: session.startTime,
+      endTime: session.endTime,
+      duration: (session.endTime || Date.now()) - session.startTime,
+      channels: Array.from(session.channels),
+      pointCount: session.pointCount,
+      sampleRate: session.metadata.sampleRate,
+      channelStats: {},
+    };
+
+    const data = timeseries.getDataRange(
+      session.metadata.minTimestamp || session.startTime,
+      session.metadata.maxTimestamp || Date.now(),
+      null,
+      targetSessionId
+    );
+
+    stats.channels.forEach((ch) => {
+      stats.channelStats[ch] = {
+        voltage: { min: Infinity, max: -Infinity, avg: 0 },
+        current: { min: Infinity, max: -Infinity, avg: 0 },
+        power: { min: Infinity, max: -Infinity, avg: 0 },
+        sampleCount: 0,
+      };
+    });
+
+    data.forEach((point) => {
+      stats.channels.forEach((ch) => {
+        const chData = point.data[`ch${ch}`];
+        if (!chData) return;
+        const chStats = stats.channelStats[ch];
+
+        chStats.voltage.min = Math.min(chStats.voltage.min, chData.voltage);
+        chStats.voltage.max = Math.max(chStats.voltage.max, chData.voltage);
+        chStats.voltage.avg += chData.voltage;
+
+        chStats.current.min = Math.min(chStats.current.min, chData.current);
+        chStats.current.max = Math.max(chStats.current.max, chData.current);
+        chStats.current.avg += chData.current;
+
+        chStats.power.min = Math.min(chStats.power.min, chData.power);
+        chStats.power.max = Math.max(chStats.power.max, chData.power);
+        chStats.power.avg += chData.power;
+
+        chStats.sampleCount++;
+      });
+    });
+
+    stats.channels.forEach((ch) => {
+      const chStats = stats.channelStats[ch];
+      if (chStats.sampleCount > 0) {
+        chStats.voltage.avg /= chStats.sampleCount;
+        chStats.current.avg /= chStats.sampleCount;
+        chStats.power.avg /= chStats.sampleCount;
+      }
+    });
+
+    return stats;
+  }
+
+  function destroy(): void {
+    unsubscribes.forEach((unsubscribe) => unsubscribe());
+  }
+
+  return {
+    startRecording,
+    stopRecording,
+    exportSessionToCSV,
+    getChartData,
+    getSessionStats,
+    destroy,
+  };
+}

--- a/mdp-webui/src/lib/stores/timeseries.ts
+++ b/mdp-webui/src/lib/stores/timeseries.ts
@@ -1,8 +1,8 @@
-import { writable, derived, get } from 'svelte/store';
+import { derived, get, writable } from 'svelte/store';
 
 /**
- * Centralized time-series data store for all channel data
- * Stores data points with timestamp correlation across channels
+ * Centralized time-series data store for all channel data.
+ * Stores data points with timestamp correlation across channels.
  */
 
 // Type definitions
@@ -14,6 +14,9 @@ interface ChannelData {
   mode: string | null;
   isOutput: boolean;
 }
+
+type ChannelKey = `ch${number}`;
+type ChannelDataByChannel = Partial<Record<ChannelKey, ChannelData>>;
 
 interface SessionMetadata {
   createdAt: Date;
@@ -27,7 +30,7 @@ interface Session {
   startTime: number;
   endTime: number | null;
   channels: Set<number>;
-  data: Map<number, Record<string, ChannelData>>;
+  data: Map<number, ChannelDataByChannel>;
   pointCount: number;
   metadata: SessionMetadata;
 }
@@ -44,7 +47,7 @@ interface TimeSeriesState {
   config: TimeSeriesConfig;
 }
 
-interface DataPoint {
+export interface TimeSeriesPoint {
   channel: number;
   timestamp: number;
   data: {
@@ -58,20 +61,18 @@ interface DataPoint {
 
 interface TimeSeriesDataPoint {
   timestamp: number;
-  data: Record<string, ChannelData>;
+  data: ChannelDataByChannel;
 }
 
 // Configuration constants
 const DEFAULT_MAX_DURATION = 3600000; // 1 hour in milliseconds
-const DEFAULT_MAX_POINTS = 100000;   // Maximum data points per session
-const CLEANUP_INTERVAL = 60000;      // Cleanup old data every minute
+const DEFAULT_MAX_POINTS = 100000; // Maximum data points per session
+const CLEANUP_INTERVAL = 60000; // Cleanup old data every minute
 
-// Helper to generate unique session IDs
-function generateSessionId() {
+function generateSessionId(): string {
   return `session-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
 }
 
-// Initialize the store state
 function createInitialState(): TimeSeriesState {
   return {
     sessions: new Map(),
@@ -79,64 +80,18 @@ function createInitialState(): TimeSeriesState {
     config: {
       maxDuration: DEFAULT_MAX_DURATION,
       maxPoints: DEFAULT_MAX_POINTS,
-      autoCleanup: true
-    }
+      autoCleanup: true,
+    },
   };
 }
 
-// Create the main store
-const store = writable(createInitialState());
-
-// Keep track of cleanup interval
-let cleanupTimer: ReturnType<typeof setInterval> | null = null;
-
-/**
- * Create a new recording session
- * @param {Array<number>} channels - Array of channel numbers to record
- * @returns {string} The new session ID
- */
-function createSession(channels: number[] = []): string {
-  const sessionId = generateSessionId();
-  const startTime = Date.now();
-  
-  store.update(state => {
-    state.sessions.set(sessionId, {
-      id: sessionId,
-      startTime,
-      endTime: null,
-      channels: new Set(channels),
-      data: new Map(), // Map<timestamp, channelData>
-      pointCount: 0,
-      metadata: {
-        createdAt: new Date(startTime),
-        sampleRate: null, // Will be calculated from first few samples
-        minTimestamp: null,
-        maxTimestamp: null
-      }
-    });
-    
-    // Auto-activate if no active session
-    if (!state.activeSessionId) {
-      state.activeSessionId = sessionId;
-    }
-    
-    return state;
-  });
-  
-  return sessionId;
-}
-
-/**
- * Add a data point for a specific channel
- * @param {number} channel - Channel number
- * @param {number} timestamp - Timestamp in milliseconds
- * @param {Object} data - Data object with voltage, current, etc.
- * @param {string} sessionId - Optional session ID (uses active if not provided)
- */
-function applyChannelData(state: TimeSeriesState, session: Session, timestamp: number, channelData: Record<string, ChannelData>): void {
-  if (session.pointCount >= state.config.maxPoints) {
-    return;
-  }
+function applyChannelData(
+  state: TimeSeriesState,
+  session: Session,
+  timestamp: number,
+  channelData: ChannelDataByChannel
+): void {
+  if (session.pointCount >= state.config.maxPoints) return;
 
   if (!session.data.has(timestamp)) {
     session.data.set(timestamp, {});
@@ -157,7 +112,7 @@ function applyChannelData(state: TimeSeriesState, session: Session, timestamp: n
 
   if (!session.metadata.sampleRate && session.data.size > 10) {
     const timestamps = Array.from(session.data.keys()).sort((a, b) => a - b);
-    const intervals = [];
+    const intervals: number[] = [];
     for (let i = 1; i < Math.min(10, timestamps.length); i++) {
       intervals.push(timestamps[i] - timestamps[i - 1]);
     }
@@ -166,300 +121,289 @@ function applyChannelData(state: TimeSeriesState, session: Session, timestamp: n
   }
 }
 
-function addDataPoint(channel: number, timestamp: number, data: DataPoint['data'], sessionId: string | null = null): void {
-  store.update(state => {
-    const targetSessionId = sessionId || state.activeSessionId;
-    if (!targetSessionId || !state.sessions.has(targetSessionId)) {
+export function createTimeseriesStore() {
+  const store = writable(createInitialState());
+  let cleanupTimer: ReturnType<typeof setInterval> | null = null;
+
+  function createSession(channels: number[] = []): string {
+    const sessionId = generateSessionId();
+    const startTime = Date.now();
+
+    store.update((state) => {
+      state.sessions.set(sessionId, {
+        id: sessionId,
+        startTime,
+        endTime: null,
+        channels: new Set(channels),
+        data: new Map(),
+        pointCount: 0,
+        metadata: {
+          createdAt: new Date(startTime),
+          sampleRate: null,
+          minTimestamp: null,
+          maxTimestamp: null,
+        },
+      });
+
+      if (!state.activeSessionId) {
+        state.activeSessionId = sessionId;
+      }
+
       return state;
-    }
-
-    const session = state.sessions.get(targetSessionId);
-    if (!session) return state;
-
-    applyChannelData(state, session, timestamp, {
-      [`ch${channel}`]: {
-        voltage: data.voltage,
-        current: data.current,
-        power: data.voltage * data.current,
-        temperature: data.temperature || null,
-        mode: data.mode || null,
-        isOutput: data.isOutput || false
-      }
     });
 
-    return state;
-  });
-}
-
-/**
- * Add multiple data points in batch
- * @param {Array<{channel, timestamp, data}>} points - Array of data points
- * @param {string} sessionId - Optional session ID
- */
-function addDataPoints(points: DataPoint[], sessionId: string | null = null): void {
-  store.update(state => {
-    const targetSessionId = sessionId || state.activeSessionId;
-    if (!targetSessionId || !state.sessions.has(targetSessionId)) {
-      return state;
-    }
-
-    const session = state.sessions.get(targetSessionId);
-    if (!session) return state;
-
-    const groupedPoints = new Map<number, Record<string, ChannelData>>();
-    points.forEach(point => {
-      if (!groupedPoints.has(point.timestamp)) {
-        groupedPoints.set(point.timestamp, {});
-      }
-      const pointData = groupedPoints.get(point.timestamp);
-      if (pointData) {
-        pointData[`ch${point.channel}`] = {
-          voltage: point.data.voltage,
-          current: point.data.current,
-          power: point.data.voltage * point.data.current,
-          temperature: point.data.temperature || null,
-          mode: point.data.mode || null,
-          isOutput: point.data.isOutput || false
-        };
-      }
-    });
-
-    groupedPoints.forEach((channelData, timestamp) => {
-      applyChannelData(state, session, timestamp, channelData);
-    });
-
-    return state;
-  });
-}
-
-/**
- * Get data for a specific time range
- * @param {number} startTime - Start timestamp
- * @param {number} endTime - End timestamp
- * @param {Array<number>} channels - Optional channel filter
- * @param {string} sessionId - Optional session ID
- * @returns {Array<{timestamp, data}>} Sorted array of data points
- */
-function getDataRange(startTime: number, endTime: number, channels: number[] | null = null, sessionId: string | null = null): TimeSeriesDataPoint[] {
-  const state = get(store);
-  const targetSessionId = sessionId || state.activeSessionId;
-  
-  if (!targetSessionId || !state.sessions.has(targetSessionId)) {
-    return [];
+    return sessionId;
   }
-  
-  const session = state.sessions.get(targetSessionId);
-  if (!session) return [];
-  
-  const result: TimeSeriesDataPoint[] = [];
-  
-  // Filter and sort timestamps
-  const timestamps = Array.from(session.data.keys())
-    .filter(ts => ts >= startTime && ts <= endTime)
-    .sort((a, b) => a - b);
-  
-  // Build result array
-  timestamps.forEach(timestamp => {
-    const data = session.data.get(timestamp);
-    if (!data) return;
-    
-    const point: TimeSeriesDataPoint = { timestamp, data: {} };
-    
-    // Filter by channels if specified
-    if (channels) {
-      channels.forEach(ch => {
-        const key = `ch${ch}`;
-        if (key in data) {
-          point.data[key] = data[key];
+
+  function addDataPoint(
+    channel: number,
+    timestamp: number,
+    data: TimeSeriesPoint['data'],
+    sessionId: string | null = null
+  ): void {
+    store.update((state) => {
+      const targetSessionId = sessionId || state.activeSessionId;
+      if (!targetSessionId || !state.sessions.has(targetSessionId)) {
+        return state;
+      }
+
+      const session = state.sessions.get(targetSessionId);
+      if (!session) return state;
+
+      applyChannelData(state, session, timestamp, {
+        [`ch${channel}`]: {
+          voltage: data.voltage,
+          current: data.current,
+          power: data.voltage * data.current,
+          temperature: data.temperature || null,
+          mode: data.mode || null,
+          isOutput: data.isOutput || false,
+        },
+      });
+
+      return state;
+    });
+  }
+
+  function addDataPoints(points: TimeSeriesPoint[], sessionId: string | null = null): void {
+    store.update((state) => {
+      const targetSessionId = sessionId || state.activeSessionId;
+      if (!targetSessionId || !state.sessions.has(targetSessionId)) {
+        return state;
+      }
+
+      const session = state.sessions.get(targetSessionId);
+      if (!session) return state;
+
+      const groupedPoints = new Map<number, ChannelDataByChannel>();
+      points.forEach((point) => {
+        if (!groupedPoints.has(point.timestamp)) {
+          groupedPoints.set(point.timestamp, {});
+        }
+        const pointData = groupedPoints.get(point.timestamp);
+        if (pointData) {
+          pointData[`ch${point.channel}`] = {
+            voltage: point.data.voltage,
+            current: point.data.current,
+            power: point.data.voltage * point.data.current,
+            temperature: point.data.temperature || null,
+            mode: point.data.mode || null,
+            isOutput: point.data.isOutput || false,
+          };
         }
       });
-    } else {
-      point.data = { ...data };
-    }
-    
-    if (Object.keys(point.data).length > 0) {
-      result.push(point);
-    }
-  });
-  
-  return result;
-}
 
-/**
- * Clean up old data based on max duration
- * @param {number} referenceTime - Optional reference time for testing
- */
-function cleanupOldData(referenceTime: number | null = null): void {
-  store.update(state => {
-    const now = referenceTime || Date.now();
-    
-    state.sessions.forEach((session, sessionId) => {
-      // Skip active session cleanup if it's still being recorded
-      if (sessionId === state.activeSessionId && !session.endTime) {
-        // For active sessions, still clean up old data points
+      groupedPoints.forEach((channelData, timestamp) => {
+        applyChannelData(state, session, timestamp, channelData);
+      });
+
+      return state;
+    });
+  }
+
+  function getDataRange(
+    startTime: number,
+    endTime: number,
+    channels: number[] | null = null,
+    sessionId: string | null = null
+  ): TimeSeriesDataPoint[] {
+    const state = get(store);
+    const targetSessionId = sessionId || state.activeSessionId;
+
+    if (!targetSessionId || !state.sessions.has(targetSessionId)) return [];
+
+    const session = state.sessions.get(targetSessionId);
+    if (!session) return [];
+
+    const result: TimeSeriesDataPoint[] = [];
+
+    const timestamps = Array.from(session.data.keys())
+      .filter((ts) => ts >= startTime && ts <= endTime)
+      .sort((a, b) => a - b);
+
+    timestamps.forEach((timestamp) => {
+      const data = session.data.get(timestamp);
+      if (!data) return;
+
+      const point: TimeSeriesDataPoint = { timestamp, data: {} };
+
+      if (channels) {
+        channels.forEach((ch) => {
+          const key = `ch${ch}` as ChannelKey;
+          const channelData = data[key];
+          if (channelData) {
+            point.data[key] = channelData;
+          }
+        });
+      } else {
+        point.data = { ...data };
+      }
+
+      if (Object.keys(point.data).length > 0) {
+        result.push(point);
+      }
+    });
+
+    return result;
+  }
+
+  function cleanupOldData(referenceTime: number | null = null): void {
+    store.update((state) => {
+      const now = referenceTime || Date.now();
+
+      state.sessions.forEach((session, sessionId) => {
         const cutoffTime = now - state.config.maxDuration;
-        const timestamps = Array.from(session.data.keys()).filter((ts: number) => ts < cutoffTime);
-        
-        timestamps.forEach(ts => {
+
+        if (sessionId === state.activeSessionId && !session.endTime) {
+          const timestamps = Array.from(session.data.keys()).filter((ts) => ts < cutoffTime);
+
+          timestamps.forEach((ts) => {
+            session.data.delete(ts);
+            session.pointCount--;
+          });
+
+          if (timestamps.length > 0) {
+            const remainingTimestamps = Array.from(session.data.keys());
+            session.metadata.minTimestamp = remainingTimestamps.length > 0 ? Math.min(...remainingTimestamps) : null;
+          }
+          return;
+        }
+
+        if (session.endTime && now - session.endTime > state.config.maxDuration) {
+          state.sessions.delete(sessionId);
+          if (state.activeSessionId === sessionId) {
+            state.activeSessionId = null;
+          }
+          return;
+        }
+
+        const timestamps = Array.from(session.data.keys()).filter((ts) => ts < cutoffTime);
+
+        timestamps.forEach((ts) => {
           session.data.delete(ts);
           session.pointCount--;
         });
-        
-        // Update metadata if we removed old points
+
         if (timestamps.length > 0) {
           const remainingTimestamps = Array.from(session.data.keys());
-          session.metadata.minTimestamp = remainingTimestamps.length > 0 
-            ? Math.min(...remainingTimestamps as number[]) 
-            : null;
+          session.metadata.minTimestamp = remainingTimestamps.length > 0 ? Math.min(...remainingTimestamps) : null;
         }
-        return;
-      }
-      
-      // Remove entire session if it's too old
-      if (session.endTime && (now - session.endTime) > state.config.maxDuration) {
-        state.sessions.delete(sessionId);
+      });
+
+      return state;
+    });
+  }
+
+  function closeSession(sessionId: string): void {
+    store.update((state) => {
+      const session = state.sessions.get(sessionId);
+      if (session) {
+        session.endTime = Date.now();
+
         if (state.activeSessionId === sessionId) {
           state.activeSessionId = null;
         }
-        return;
       }
-      
-      // Clean up old data points within session
-      const cutoffTime = now - state.config.maxDuration;
-      const timestamps = Array.from(session.data.keys()).filter((ts: number) => ts < cutoffTime);
-      
-      timestamps.forEach(ts => {
-        session.data.delete(ts);
-        session.pointCount--;
-      });
-      
-      // Update metadata if we removed old points
-      if (timestamps.length > 0) {
-        const remainingTimestamps = Array.from(session.data.keys());
-        session.metadata.minTimestamp = remainingTimestamps.length > 0 
-          ? Math.min(...remainingTimestamps as number[]) 
-          : null;
-      }
+      return state;
     });
-    
-    return state;
-  });
-}
+  }
 
-/**
- * Close a session
- * @param {string} sessionId - Session ID to close
- */
-function closeSession(sessionId: string): void {
-  store.update(state => {
-    const session = state.sessions.get(sessionId);
-    if (session) {
-      session.endTime = Date.now();
-      
-      // If this was the active session, clear it
-      if (state.activeSessionId === sessionId) {
-        state.activeSessionId = null;
+  function setActiveSession(sessionId: string): void {
+    store.update((state) => {
+      if (state.sessions.has(sessionId)) {
+        state.activeSessionId = sessionId;
       }
+      return state;
+    });
+  }
+
+  function updateConfig(config: Partial<TimeSeriesConfig>): void {
+    store.update((state) => {
+      Object.assign(state.config, config);
+      return state;
+    });
+  }
+
+  function reset(): void {
+    if (cleanupTimer) {
+      clearInterval(cleanupTimer);
+      cleanupTimer = null;
     }
-    return state;
-  });
-}
+    store.set(createInitialState());
+  }
 
-/**
- * Set the active session
- * @param {string} sessionId - Session ID to activate
- */
-function setActiveSession(sessionId: string): void {
-  store.update(state => {
-    if (state.sessions.has(sessionId)) {
-      state.activeSessionId = sessionId;
+  function startAutoCleanup(): void {
+    const state = get(store);
+    if (state.config.autoCleanup && !cleanupTimer) {
+      cleanupTimer = setInterval(cleanupOldData, CLEANUP_INTERVAL);
     }
-    return state;
+  }
+
+  function stopAutoCleanup(): void {
+    if (cleanupTimer) {
+      clearInterval(cleanupTimer);
+      cleanupTimer = null;
+    }
+  }
+
+  const activeSession = derived(store, ($store) => {
+    if ($store.activeSessionId && $store.sessions.has($store.activeSessionId)) {
+      return $store.sessions.get($store.activeSessionId) ?? null;
+    }
+    return null;
   });
-}
 
-/**
- * Update configuration
- * @param {Object} config - Configuration updates
- */
-function updateConfig(config: Partial<TimeSeriesConfig>): void {
-  store.update(state => {
-    Object.assign(state.config, config);
-    return state;
+  const sessionList = derived(store, ($store) => {
+    return Array.from($store.sessions.values()).sort((a, b) => b.startTime - a.startTime);
   });
+
+  const activeSessionData = derived(activeSession, ($session) => {
+    if (!$session) return [];
+
+    return Array.from($session.data.entries())
+      .map(([timestamp, data]) => ({ timestamp, ...data }))
+      .sort((a, b) => a.timestamp - b.timestamp);
+  });
+
+  return {
+    subscribe: store.subscribe,
+    createSession,
+    addDataPoint,
+    addDataPoints,
+    getDataRange,
+    closeSession,
+    setActiveSession,
+    updateConfig,
+    cleanupOldData,
+    startAutoCleanup,
+    stopAutoCleanup,
+    reset,
+    activeSession,
+    sessionList,
+    activeSessionData,
+  };
 }
 
-/**
- * Reset the entire store
- */
-function reset(): void {
-  if (cleanupTimer) {
-    clearInterval(cleanupTimer);
-    cleanupTimer = null;
-  }
-  store.set(createInitialState());
-}
+export type TimeseriesStore = ReturnType<typeof createTimeseriesStore>;
 
-/**
- * Start automatic cleanup if enabled
- */
-function startAutoCleanup(): void {
-  const state = get(store);
-  if (state.config.autoCleanup && !cleanupTimer) {
-    cleanupTimer = setInterval(cleanupOldData, CLEANUP_INTERVAL);
-  }
-}
-
-/**
- * Stop automatic cleanup
- */
-function stopAutoCleanup(): void {
-  if (cleanupTimer) {
-    clearInterval(cleanupTimer);
-    cleanupTimer = null;
-  }
-}
-
-// Derived stores for convenience
-const activeSession = derived(store, $store => {
-  if ($store.activeSessionId && $store.sessions.has($store.activeSessionId)) {
-    return $store.sessions.get($store.activeSessionId);
-  }
-  return null;
-});
-
-const sessionList = derived(store, $store => {
-  return Array.from($store.sessions.values())
-    .sort((a, b) => b.startTime - a.startTime);
-});
-
-const activeSessionData = derived(activeSession, $session => {
-  if (!$session) return [];
-  
-  return Array.from($session.data.entries())
-    .map(([timestamp, data]: [number, Record<string, ChannelData>]) => ({ timestamp, ...data }))
-    .sort((a, b) => a.timestamp - b.timestamp);
-});
-
-// Don't auto-start cleanup - let consumers decide
-// startAutoCleanup();
-
-// Export the store and functions
-export const timeseriesStore = {
-  subscribe: store.subscribe,
-  createSession,
-  addDataPoint,
-  addDataPoints,
-  getDataRange,
-  closeSession,
-  setActiveSession,
-  updateConfig,
-  cleanupOldData,
-  startAutoCleanup,
-  stopAutoCleanup,
-  reset,
-  // Derived stores
-  activeSession,
-  sessionList,
-  activeSessionData
-};
+export const timeseriesStore = createTimeseriesStore();

--- a/mdp-webui/src/main.ts
+++ b/mdp-webui/src/main.ts
@@ -1,15 +1,20 @@
-import { mount } from 'svelte'
-import './app.css'
-import App from './App.svelte'
-import { initializeTimeseriesIntegration } from './lib/stores/timeseries-integration.js'
-
-initializeTimeseriesIntegration()
+import { mount } from 'svelte';
+import './app.css';
+import App from './App.svelte';
+import { createRuntime } from './lib/app/runtime';
 
 const target = document.getElementById('app');
 if (!target) throw new Error('Could not find app element');
 
+const runtime = createRuntime();
+
 const app = mount(App, {
   target: target,
+  props: { runtime },
 })
+
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => runtime.destroy());
+}
 
 export default app

--- a/mdp-webui/tests/components/App.connection.test.js
+++ b/mdp-webui/tests/components/App.connection.test.js
@@ -1,62 +1,6 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { render, fireEvent, waitFor } from '@testing-library/svelte';
 import { writable } from 'svelte/store';
-import App from '../../src/App.svelte';
-
-// Mock serial connection
-vi.mock('$lib/serial.js', () => {
-  const mockStatus = writable('disconnected');
-  const mockError = writable(null);
-  const mockDeviceType = writable(null);
-  
-  return {
-    serialConnection: {
-      status: mockStatus,
-      error: mockError,
-      deviceType: mockDeviceType,
-      connect: vi.fn(),
-      disconnect: vi.fn(),
-      registerPacketHandler: vi.fn(),
-      clearPacketHandlers: vi.fn(),
-      sendPacket: vi.fn(),
-      stopHeartbeat: vi.fn()
-    },
-    ConnectionStatus: {
-      DISCONNECTED: 'disconnected',
-      CONNECTING: 'connecting',
-      CONNECTED: 'connected',
-      ERROR: 'error'
-    }
-  };
-});
-
-// Mock channel store
-vi.mock('$lib/stores/channels.js', () => {
-  const mockChannels = writable(Array(6).fill(null).map((_, i) => ({
-    channel: i,
-    online: false,
-    machineType: 'Unknown',
-    voltage: 0,
-    current: 0,
-    power: 0,
-    temperature: 0,
-    isOutput: false,
-    mode: 'CV',
-    recording: false,
-    waveformData: []
-  })));
-  
-  return {
-    channelStore: {
-      channels: mockChannels,
-      activeChannel: writable(0),
-      reset: vi.fn(),
-      setActiveChannel: vi.fn(),
-      startRecording: vi.fn(),
-      stopRecording: vi.fn()
-    }
-  };
-});
 
 // Mock Dashboard and ChannelDetail components
 vi.mock('$lib/components/Dashboard.svelte', async () => {
@@ -69,129 +13,173 @@ vi.mock('$lib/components/ChannelDetail.svelte', async () => {
   return { default: MockChannelDetail.default };
 });
 
-import { serialConnection, ConnectionStatus } from '$lib/serial.js';
-import { channelStore } from '$lib/stores/channels.js';
+import App from '../../src/App.svelte';
+
+function createRuntimeStub() {
+  const status = writable('disconnected');
+  const error = writable(null);
+  const deviceType = writable(null);
+
+  const serial = {
+    status,
+    error,
+    deviceType,
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  };
+
+  const channels = writable(
+    Array.from({ length: 6 }, (_, i) => ({
+      channel: i,
+      online: false,
+      machineType: 'Unknown',
+      voltage: 0,
+      current: 0,
+      power: 0,
+      temperature: 0,
+      isOutput: false,
+      mode: 'CV',
+      recording: false,
+      waveformData: [],
+    }))
+  );
+
+  const channelStore = {
+    channels,
+    activeChannel: writable(0),
+    reset: vi.fn(),
+    setActiveChannel: vi.fn(),
+    startRecording: vi.fn(),
+    stopRecording: vi.fn(),
+    setVoltage: vi.fn(),
+    setCurrent: vi.fn(),
+    setOutput: vi.fn(),
+  };
+
+  return {
+    serial,
+    channels: channelStore,
+    packets: {},
+    sparklines: {},
+    timeseries: {},
+    timeseriesIntegration: {},
+    destroy: vi.fn(),
+  };
+}
 
 describe('App Connection Management Tests', () => {
-  const { status: mockStatus, error: mockError, deviceType: mockDeviceType } = serialConnection;
-  
+  let runtime;
+
   beforeEach(() => {
     vi.clearAllMocks();
-    mockStatus.set('disconnected');
-    mockError.set(null);
-    mockDeviceType.set(null);
+    runtime = createRuntimeStub();
+    runtime.serial.status.set('disconnected');
+    runtime.serial.error.set(null);
+    runtime.serial.deviceType.set(null);
   });
 
   describe('Connection States', () => {
-    it('should show connect button when disconnected', () => {
-      const { getByText } = render(App);
-      
+    it('shows connect button when disconnected', () => {
+      const { getByText } = render(App, { props: { runtime } });
       expect(getByText('Connect')).toBeInTheDocument();
     });
 
-    it('should show connecting state', async () => {
-      const { getByText } = render(App);
-      
-      // Mock connect to set connecting state
-      serialConnection.connect.mockImplementation(() => {
-        mockStatus.set('connecting');
-        return new Promise(() => {}); // Never resolves
+    it('shows connecting state', async () => {
+      const { getByText } = render(App, { props: { runtime } });
+
+      runtime.serial.connect.mockImplementation(() => {
+        runtime.serial.status.set('connecting');
+        return new Promise(() => {});
       });
-      
+
       await fireEvent.pointerDown(getByText('Connect'));
       await fireEvent.pointerUp(getByText('Connect'));
-      
+
       await waitFor(() => {
         expect(getByText('Connecting...')).toBeInTheDocument();
       });
     });
 
-    it('should show connected state with disconnect button', async () => {
-      const { getByText } = render(App);
-      
-      // Mock successful connection
-      serialConnection.connect.mockImplementation(async () => {
-        mockStatus.set('connecting');
-        await new Promise(resolve => setTimeout(resolve, 10));
-        mockStatus.set('connected');
+    it('shows connected state with disconnect button', async () => {
+      const { getByText } = render(App, { props: { runtime } });
+
+      runtime.serial.connect.mockImplementation(async () => {
+        runtime.serial.status.set('connecting');
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        runtime.serial.status.set('connected');
       });
-      
+
       await fireEvent.pointerDown(getByText('Connect'));
       await fireEvent.pointerUp(getByText('Connect'));
-      
+
       await waitFor(() => {
         expect(getByText('Connected')).toBeInTheDocument();
         expect(getByText('Disconnect')).toBeInTheDocument();
       });
     });
 
-    it('should show device type when available', async () => {
-      mockStatus.set('connected');
-      mockDeviceType.set({ type: 'M01' });
-      
-      const { getByText } = render(App);
-      
+    it('shows device type when available', async () => {
+      runtime.serial.status.set('connected');
+      runtime.serial.deviceType.set({ type: 'M01' });
+
+      const { getByText } = render(App, { props: { runtime } });
       expect(getByText('(M01)')).toBeInTheDocument();
     });
   });
 
   describe('Error Handling', () => {
-    it('should show error state with retry button', async () => {
-      const { getByText } = render(App);
-      
-      // Mock connection error
-      serialConnection.connect.mockImplementation(async () => {
-        mockStatus.set('connecting');
-        await new Promise(resolve => setTimeout(resolve, 10));
-        mockStatus.set('error');
-        mockError.set('Port not available');
+    it('shows error state with retry button', async () => {
+      const { getByText } = render(App, { props: { runtime } });
+
+      runtime.serial.connect.mockImplementation(async () => {
+        runtime.serial.status.set('connecting');
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        runtime.serial.status.set('error');
+        runtime.serial.error.set('Port not available');
         throw new Error('Port not available');
       });
-      
+
       await fireEvent.pointerDown(getByText('Connect'));
       await fireEvent.pointerUp(getByText('Connect'));
-      
+
       await waitFor(() => {
         expect(getByText('Error: Port not available')).toBeInTheDocument();
         expect(getByText('Retry')).toBeInTheDocument();
       });
     });
 
-    it('should handle Web Serial API not supported', async () => {
-      const { getByText } = render(App);
-      
-      serialConnection.connect.mockRejectedValue(
+    it('handles Web Serial API not supported', async () => {
+      const { getByText } = render(App, { props: { runtime } });
+
+      runtime.serial.connect.mockRejectedValue(
         new Error('Web Serial API not supported. Please use Chrome, Edge, or Opera.')
       );
-      
+
       await fireEvent.pointerDown(getByText('Connect'));
       await fireEvent.pointerUp(getByText('Connect'));
-      
-      // Error should be logged but UI handles gracefully
-      expect(serialConnection.connect).toHaveBeenCalled();
+
+      expect(runtime.serial.connect).toHaveBeenCalled();
     });
   });
 
   describe('Disconnection', () => {
-    it('should disconnect when button clicked', async () => {
-      mockStatus.set('connected');
-      
-      const { getByText } = render(App);
-      
+    it('disconnects when button clicked', async () => {
+      runtime.serial.status.set('connected');
+
+      const { getByText } = render(App, { props: { runtime } });
+
       await fireEvent.pointerDown(getByText('Disconnect'));
       await fireEvent.pointerUp(getByText('Disconnect'));
-      
-      expect(serialConnection.disconnect).toHaveBeenCalled();
+
+      expect(runtime.serial.disconnect).toHaveBeenCalled();
     });
 
-    it('should handle disconnection during operation', async () => {
-      mockStatus.set('connected');
-      
-      const { getByText } = render(App);
-      
-      // Simulate sudden disconnection
-      mockStatus.set('disconnected');
-      
+    it('handles disconnection during operation', async () => {
+      runtime.serial.status.set('connected');
+      const { getByText } = render(App, { props: { runtime } });
+
+      runtime.serial.status.set('disconnected');
+
       await waitFor(() => {
         expect(getByText('Connect')).toBeInTheDocument();
       });
@@ -199,52 +187,42 @@ describe('App Connection Management Tests', () => {
   });
 
   describe('View Navigation', () => {
-    it('should show dashboard when connected', async () => {
-      mockStatus.set('connected');
-      
-      const { container } = render(App);
-      
-      expect(container.querySelector('[data-testid="mock-dashboard"]')).toBeInTheDocument();
+    it('shows dashboard when connected', () => {
+      runtime.serial.status.set('connected');
+      const { container } = render(App, { props: { runtime } });
+      expect(container.querySelector('[data-testid=\"mock-dashboard\"]')).toBeInTheDocument();
     });
 
-    it('should navigate to channel detail', async () => {
-      mockStatus.set('connected');
-      
-      const { container, component } = render(App);
-      
-      // Call the navigation method
+    it('navigates to channel detail', async () => {
+      runtime.serial.status.set('connected');
+      const { container, component } = render(App, { props: { runtime } });
+
       component.showChannelDetail(2);
-      
+
       await waitFor(() => {
-        const channelDetail = container.querySelector('[data-testid="mock-channel-detail"]');
+        const channelDetail = container.querySelector('[data-testid=\"mock-channel-detail\"]');
         expect(channelDetail).toBeInTheDocument();
         expect(channelDetail.textContent).toContain('Channel 3');
       });
     });
 
-    it('should navigate back to dashboard', async () => {
-      mockStatus.set('connected');
-      
-      const { container, component } = render(App);
-      
-      // Go to channel detail
+    it('navigates back to dashboard', async () => {
+      runtime.serial.status.set('connected');
+      const { container, component } = render(App, { props: { runtime } });
+
       component.showChannelDetail(1);
-      
       await waitFor(() => {
-        expect(container.querySelector('[data-testid="mock-channel-detail"]')).toBeInTheDocument();
+        expect(container.querySelector('[data-testid=\"mock-channel-detail\"]')).toBeInTheDocument();
       });
-      
-      // Go back to dashboard
+
       component.showDashboard();
-      
       await waitFor(() => {
-        expect(container.querySelector('[data-testid="mock-dashboard"]')).toBeInTheDocument();
+        expect(container.querySelector('[data-testid=\"mock-dashboard\"]')).toBeInTheDocument();
       });
     });
 
-    it('should show placeholder when disconnected', () => {
-      const { getByText } = render(App);
-      
+    it('shows placeholder when disconnected', () => {
+      const { getByText } = render(App, { props: { runtime } });
       expect(getByText('Connect to your MDP device to begin')).toBeInTheDocument();
     });
   });

--- a/mdp-webui/tests/components/ChannelDetail.test.js
+++ b/mdp-webui/tests/components/ChannelDetail.test.js
@@ -28,23 +28,23 @@ vi.mock('$lib/components/WaveformChart.svelte', async () => ({
   default: (await vi.importActual('../mocks/components/MockWaveformChart.svelte')).default
 }));
 
-vi.mock('$lib/stores/channels.js', () => ({
-  channelStore: {
-    channels: writable([]),
-    activeChannel: writable(0),
-    setActiveChannel: vi.fn(),
-    setVoltage: vi.fn(),
-    setCurrent: vi.fn(),
-    setOutput: vi.fn(),
-    startRecording: vi.fn(),
-    stopRecording: vi.fn(),
-    clearRecording: vi.fn()
-  }
-}));
-
-// Import component after mocks
-import { channelStore } from '$lib/stores/channels.js';
 import ChannelDetail from '$lib/components/ChannelDetail.svelte';
+
+const channelStore = {
+  channels: writable([]),
+  activeChannel: writable(0),
+  setActiveChannel: vi.fn(),
+  setVoltage: vi.fn(),
+  setCurrent: vi.fn(),
+  setOutput: vi.fn(),
+  startRecording: vi.fn(),
+  stopRecording: vi.fn(),
+  clearRecording: vi.fn(),
+};
+
+function renderChannelDetail(props) {
+  return render(ChannelDetail, { props: { channelStore, ...props } });
+}
 
 describe('ChannelDetail Component', () => {
   let mockChannelData;
@@ -86,7 +86,7 @@ describe('ChannelDetail Component', () => {
 
   describe('Header and Navigation', () => {
     it('should display channel number and machine type', () => {
-      const { getByText } = render(ChannelDetail, { props: { channel: 0 } });
+      const { getByText } = renderChannelDetail({ channel: 0 });
       
       expect(getByText('Channel 1 - P906')).toBeInTheDocument();
       expect(getByText('← Back')).toBeInTheDocument();
@@ -94,7 +94,7 @@ describe('ChannelDetail Component', () => {
 
     it('should call onback prop when back button clicked', async () => {
       const backHandler = vi.fn();
-      const { getByText } = render(ChannelDetail, { props: { channel: 0, onback: backHandler } });
+      const { getByText } = renderChannelDetail({ channel: 0, onback: backHandler });
       
       await fireEvent.pointerDown(getByText('← Back'));
       await fireEvent.pointerUp(getByText('← Back'));
@@ -106,7 +106,7 @@ describe('ChannelDetail Component', () => {
       mockChannelData[2].online = false;
       setMockChannels(mockChannelData);
       
-      const { getByText } = render(ChannelDetail, { props: { channel: 2 } });
+      const { getByText } = renderChannelDetail({ channel: 2 });
       
       expect(getByText('Channel 3 is offline')).toBeInTheDocument();
     });
@@ -114,7 +114,7 @@ describe('ChannelDetail Component', () => {
 
   describe('Output Control', () => {
     it('should display output status', () => {
-      const { getByText } = render(ChannelDetail, { props: { channel: 0 } });
+      const { getByText } = renderChannelDetail({ channel: 0 });
       
       const button = getByText('Output: ON');
       expect(button).toBeInTheDocument();
@@ -122,7 +122,7 @@ describe('ChannelDetail Component', () => {
     });
 
     it('should toggle output when clicked', async () => {
-      const { getByText } = render(ChannelDetail, { props: { channel: 0 } });
+      const { getByText } = renderChannelDetail({ channel: 0 });
       
       await fireEvent.pointerDown(getByText('Output: ON'));
       await fireEvent.pointerUp(getByText('Output: ON'));
@@ -134,7 +134,7 @@ describe('ChannelDetail Component', () => {
       mockChannelData[0].isOutput = false;
       setMockChannels(mockChannelData);
       
-      const { getByText } = render(ChannelDetail, { props: { channel: 0 } });
+      const { getByText } = renderChannelDetail({ channel: 0 });
       
       const button = getByText('Output: OFF');
       expect(button).not.toHaveClass('on');
@@ -143,7 +143,7 @@ describe('ChannelDetail Component', () => {
 
   describe('Parameter Configuration', () => {
     it('should display voltage and current inputs', () => {
-      const { getByLabelText } = render(ChannelDetail, { props: { channel: 0 } });
+      const { getByLabelText } = renderChannelDetail({ channel: 0 });
       
       const voltageInput = getByLabelText(/Voltage \(V\)/);
       const currentInput = getByLabelText(/Current \(A\)/);
@@ -153,7 +153,7 @@ describe('ChannelDetail Component', () => {
     });
 
     it('should set voltage when Set V clicked', async () => {
-      const { getByLabelText, getByText } = render(ChannelDetail, { props: { channel: 0 } });
+      const { getByLabelText, getByText } = renderChannelDetail({ channel: 0 });
       
       const voltageInput = getByLabelText(/Voltage \(V\)/);
       await fireEvent.input(voltageInput, { target: { value: '5' } });
@@ -165,7 +165,7 @@ describe('ChannelDetail Component', () => {
     });
 
     it('should set current when Set I clicked', async () => {
-      const { getByLabelText, getByText } = render(ChannelDetail, { props: { channel: 0 } });
+      const { getByLabelText, getByText } = renderChannelDetail({ channel: 0 });
       
       const currentInput = getByLabelText(/Current \(A\)/);
       await fireEvent.input(currentInput, { target: { value: '1.5' } });
@@ -177,7 +177,7 @@ describe('ChannelDetail Component', () => {
     });
 
     it('should validate input ranges', () => {
-      const { getByLabelText } = render(ChannelDetail, { props: { channel: 0 } });
+      const { getByLabelText } = renderChannelDetail({ channel: 0 });
       
       const voltageInput = getByLabelText(/Voltage \(V\)/);
       const currentInput = getByLabelText(/Current \(A\)/);
@@ -192,7 +192,7 @@ describe('ChannelDetail Component', () => {
     });
 
     it('should handle decimal inputs', async () => {
-      const { getByLabelText, getByText } = render(ChannelDetail, { props: { channel: 0 } });
+      const { getByLabelText, getByText } = renderChannelDetail({ channel: 0 });
       
       const voltageInput = getByLabelText(/Voltage \(V\)/);
       await fireEvent.input(voltageInput, { target: { value: '12.345' } });
@@ -206,7 +206,7 @@ describe('ChannelDetail Component', () => {
 
   describe('Output Measurements Display', () => {
     it('should display all measurements', () => {
-      const { getAllByText, getByText } = render(ChannelDetail, { props: { channel: 0 } });
+      const { getAllByText, getByText } = renderChannelDetail({ channel: 0 });
       
       // Check that voltage, current, and power values are displayed (may appear multiple times)
       expect(getAllByText('3.300 V').length).toBeGreaterThan(0);
@@ -216,7 +216,7 @@ describe('ChannelDetail Component', () => {
     });
 
     it('should update when channel data changes', async () => {
-      const { getByText, rerender } = render(ChannelDetail, { props: { channel: 0 } });
+      const { getByText, rerender } = renderChannelDetail({ channel: 0 });
       
       // Update channel data
       mockChannelData[0].voltage = 5.123;
@@ -225,7 +225,7 @@ describe('ChannelDetail Component', () => {
       mockChannelData[0].temperature = 30.7;
       setMockChannels([...mockChannelData]);
       
-      await rerender({ channel: 0 });
+      await rerender({ channelStore, channel: 0 });
       
       expect(getByText('5.123 V')).toBeInTheDocument();
       expect(getByText('1.234 A')).toBeInTheDocument();
@@ -236,13 +236,13 @@ describe('ChannelDetail Component', () => {
 
   describe('Recording Functionality', () => {
     it('should show start recording button when not recording', () => {
-      const { getByText } = render(ChannelDetail, { props: { channel: 0 } });
+      const { getByText } = renderChannelDetail({ channel: 0 });
       
       expect(getByText('Start Recording')).toBeInTheDocument();
     });
 
     it('should start recording when button clicked', async () => {
-      const { getByText } = render(ChannelDetail, { props: { channel: 0 } });
+      const { getByText } = renderChannelDetail({ channel: 0 });
       
       await fireEvent.pointerDown(getByText('Start Recording'));
       await fireEvent.pointerUp(getByText('Start Recording'));
@@ -254,14 +254,14 @@ describe('ChannelDetail Component', () => {
       mockChannelData[0].recording = true;
       setMockChannels(mockChannelData);
       
-      const { getByText } = render(ChannelDetail, { props: { channel: 0 } });
+      const { getByText } = renderChannelDetail({ channel: 0 });
       
       expect(getByText('Stop Recording')).toBeInTheDocument();
       expect(getByText('Recording... 0:00')).toBeInTheDocument();
     });
 
     it('should update timer during recording', async () => {
-      const { getByText } = render(ChannelDetail, { props: { channel: 0 } });
+      const { getByText } = renderChannelDetail({ channel: 0 });
       
       // Start recording by clicking the button
       await fireEvent.pointerDown(getByText('Start Recording'));
@@ -283,7 +283,7 @@ describe('ChannelDetail Component', () => {
       mockChannelData[0].recording = true;
       setMockChannels(mockChannelData);
       
-      const { getByText } = render(ChannelDetail, { props: { channel: 0 } });
+      const { getByText } = renderChannelDetail({ channel: 0 });
       
       await fireEvent.pointerDown(getByText('Stop Recording'));
       await fireEvent.pointerUp(getByText('Stop Recording'));
@@ -298,7 +298,7 @@ describe('ChannelDetail Component', () => {
       ];
       setMockChannels(mockChannelData);
       
-      const { getByText } = render(ChannelDetail, { props: { channel: 0 } });
+      const { getByText } = renderChannelDetail({ channel: 0 });
       
       expect(getByText('Export Data')).toBeInTheDocument();
       expect(getByText('2 points')).toBeInTheDocument();
@@ -314,7 +314,7 @@ describe('ChannelDetail Component', () => {
       ];
       setMockChannels(mockChannelData);
       
-      const { getByText } = render(ChannelDetail, { props: { channel: 0 } });
+      const { getByText } = renderChannelDetail({ channel: 0 });
       
       await fireEvent.pointerDown(getByText('Export Data'));
       await fireEvent.pointerUp(getByText('Export Data'));
@@ -335,7 +335,7 @@ describe('ChannelDetail Component', () => {
     });
 
     it('should not show export for empty data', () => {
-      const { queryByText } = render(ChannelDetail, { props: { channel: 0 } });
+      const { queryByText } = renderChannelDetail({ channel: 0 });
       
       expect(queryByText('Export Data')).not.toBeInTheDocument();
     });
@@ -351,7 +351,7 @@ describe('ChannelDetail Component', () => {
       mockChannelData[0].waveformData = largeData;
       setMockChannels(mockChannelData);
       
-      const { getByText } = render(ChannelDetail, { props: { channel: 0 } });
+      const { getByText } = renderChannelDetail({ channel: 0 });
       
       expect(getByText('1000 points')).toBeInTheDocument();
       
@@ -365,7 +365,7 @@ describe('ChannelDetail Component', () => {
 
   describe('Component Lifecycle', () => {
     it('should set active channel on mount', () => {
-      render(ChannelDetail, { props: { channel: 3 } });
+      renderChannelDetail({ channel: 3 });
       
       expect(channelStore.setActiveChannel).toHaveBeenCalledWith(3);
     });
@@ -381,7 +381,7 @@ describe('ChannelDetail Component', () => {
       };
       setMockChannels(mockChannelData);
       
-      const { getByLabelText } = render(ChannelDetail, { props: { channel: 2 } });
+      const { getByLabelText } = renderChannelDetail({ channel: 2 });
       
       // Should use actual values when targets are 0
       expect(getByLabelText(/Voltage \(V\)/)).toHaveValue(12);
@@ -392,7 +392,7 @@ describe('ChannelDetail Component', () => {
       mockChannelData[0].recording = true;
       setMockChannels(mockChannelData);
       
-      const { unmount } = render(ChannelDetail, { props: { channel: 0 } });
+      const { unmount } = renderChannelDetail({ channel: 0 });
       
       // Start timer
       vi.advanceTimersByTime(1000);
@@ -410,7 +410,7 @@ describe('ChannelDetail Component', () => {
       mockChannelData[0].machineType = 'P905';
       setMockChannels(mockChannelData);
       
-      const { getByText } = render(ChannelDetail, { props: { channel: 0 } });
+      const { getByText } = renderChannelDetail({ channel: 0 });
       
       expect(getByText('Channel 1 - P905')).toBeInTheDocument();
     });
@@ -420,7 +420,7 @@ describe('ChannelDetail Component', () => {
       mockChannelData[0].mode = 'CC';
       setMockChannels(mockChannelData);
       
-      const { getByText } = render(ChannelDetail, { props: { channel: 0 } });
+      const { getByText } = renderChannelDetail({ channel: 0 });
       
       expect(getByText('Channel 1 - L1060')).toBeInTheDocument();
       // Future: Add mode selection UI for L1060
@@ -430,7 +430,7 @@ describe('ChannelDetail Component', () => {
       mockChannelData[0].machineType = 'Unknown';
       setMockChannels(mockChannelData);
       
-      const { getByText } = render(ChannelDetail, { props: { channel: 0 } });
+      const { getByText } = renderChannelDetail({ channel: 0 });
       
       expect(getByText('Channel 1 - Unknown')).toBeInTheDocument();
     });
@@ -438,19 +438,19 @@ describe('ChannelDetail Component', () => {
 
   describe('Edge Cases', () => {
     it('should handle channel index out of bounds', () => {
-      const { getByText } = render(ChannelDetail, { props: { channel: 10 } });
+      const { getByText } = renderChannelDetail({ channel: 10 });
       
       expect(getByText('Channel 11 is offline')).toBeInTheDocument();
     });
 
     it('should handle negative channel index', () => {
-      const { getByText } = render(ChannelDetail, { props: { channel: -1 } });
+      const { getByText } = renderChannelDetail({ channel: -1 });
       
       expect(getByText('Channel 0 is offline')).toBeInTheDocument();
     });
 
     it('should handle very long recording sessions', async () => {
-      const { getByText } = render(ChannelDetail, { props: { channel: 0 } });
+      const { getByText } = renderChannelDetail({ channel: 0 });
       
       // Start recording by clicking the button
       await fireEvent.pointerDown(getByText('Start Recording'));
@@ -471,7 +471,7 @@ describe('ChannelDetail Component', () => {
     });
 
     it('should handle rapid parameter changes', async () => {
-      const { getByLabelText, getByText } = render(ChannelDetail, { props: { channel: 0 } });
+      const { getByLabelText, getByText } = renderChannelDetail({ channel: 0 });
       
       const voltageInput = getByLabelText(/Voltage \(V\)/);
       
@@ -486,7 +486,7 @@ describe('ChannelDetail Component', () => {
     });
 
     it('should handle NaN or invalid inputs gracefully', async () => {
-      const { getByLabelText, getByText } = render(ChannelDetail, { props: { channel: 0 } });
+      const { getByLabelText, getByText } = renderChannelDetail({ channel: 0 });
       
       const voltageInput = getByLabelText(/Voltage \(V\)/);
       await fireEvent.input(voltageInput, { target: { value: 'abc' } });
@@ -502,14 +502,14 @@ describe('ChannelDetail Component', () => {
 
   describe('Accessibility', () => {
     it('should have proper labels for inputs', () => {
-      const { getByLabelText } = render(ChannelDetail, { props: { channel: 0 } });
+      const { getByLabelText } = renderChannelDetail({ channel: 0 });
       
       expect(getByLabelText(/Voltage \(V\)/)).toBeInTheDocument();
       expect(getByLabelText(/Current \(A\)/)).toBeInTheDocument();
     });
 
     it('should have semantic headings', () => {
-      const { container } = render(ChannelDetail, { props: { channel: 0 } });
+      const { container } = renderChannelDetail({ channel: 0 });
       
       const headings = container.querySelectorAll('h2, h3');
       expect(headings.length).toBeGreaterThan(0);

--- a/mdp-webui/tests/components/Dashboard.channel.test.js
+++ b/mdp-webui/tests/components/Dashboard.channel.test.js
@@ -3,23 +3,10 @@ import { render, fireEvent, waitFor } from '@testing-library/svelte';
 import { writable } from 'svelte/store';
 import Dashboard from '$lib/components/Dashboard.svelte';
 
-// Mock channel store
-vi.mock('$lib/stores/channels.js', () => {
+describe('Dashboard Channel Management Tests', () => {
   const channels = writable([]);
   const activeChannel = writable(0);
-  
-  return {
-    channelStore: {
-      channels,
-      activeChannel
-    }
-  };
-});
-
-import { channelStore } from '$lib/stores/channels.js';
-
-describe('Dashboard Channel Management Tests', () => {
-  const { channels, activeChannel } = channelStore;
+  const channelStore = { channels, activeChannel };
   let mockChannelData;
 
   beforeEach(() => {
@@ -101,28 +88,28 @@ describe('Dashboard Channel Management Tests', () => {
 
   describe('Channel Display', () => {
     it('should display all 6 channels', () => {
-      const { container } = render(Dashboard);
+      const { container } = render(Dashboard, { props: { channelStore } });
       
       const channelCards = container.querySelectorAll('.channel-card');
       expect(channelCards.length).toBe(6);
     });
 
     it('should show online status for connected channels', () => {
-      const { getAllByText } = render(Dashboard);
+      const { getAllByText } = render(Dashboard, { props: { channelStore } });
       
       const onlineElements = getAllByText('Online');
       expect(onlineElements.length).toBe(2); // Channels 0 and 1
     });
 
     it('should show offline status for disconnected channels', () => {
-      const { getAllByText } = render(Dashboard);
+      const { getAllByText } = render(Dashboard, { props: { channelStore } });
       
       const offlineElements = getAllByText('Offline');
       expect(offlineElements.length).toBe(4); // Channels 2-5
     });
 
     it('should display channel measurements', () => {
-      const { getByText } = render(Dashboard);
+      const { getByText } = render(Dashboard, { props: { channelStore } });
       
       // Check channel 0 measurements
       expect(getByText('5.000 V')).toBeInTheDocument();
@@ -138,14 +125,14 @@ describe('Dashboard Channel Management Tests', () => {
     });
 
     it('should display machine types', () => {
-      const { getByText } = render(Dashboard);
+      const { getByText } = render(Dashboard, { props: { channelStore } });
       
       expect(getByText('P906')).toBeInTheDocument();
       expect(getByText('P905')).toBeInTheDocument();
     });
 
     it('should display output status', () => {
-      const { getAllByText } = render(Dashboard);
+      const { getAllByText } = render(Dashboard, { props: { channelStore } });
       
       expect(getAllByText('Output: ON').length).toBe(1);
       expect(getAllByText('Output: OFF').length).toBe(1);
@@ -154,7 +141,7 @@ describe('Dashboard Channel Management Tests', () => {
 
   describe('Channel Selection', () => {
     it('should highlight active channel', () => {
-      const { container } = render(Dashboard);
+      const { container } = render(Dashboard, { props: { channelStore } });
       
       const channelCards = container.querySelectorAll('.channel-card');
       expect(channelCards[0]).toHaveClass('active');
@@ -163,7 +150,7 @@ describe('Dashboard Channel Management Tests', () => {
 
     it('should emit select event when channel clicked', async () => {
       const onselectchannel = vi.fn();
-      const { container } = render(Dashboard, { props: { onselectchannel } });
+      const { container } = render(Dashboard, { props: { channelStore, onselectchannel } });
       
       const channelCards = container.querySelectorAll('.channel-card');
       await fireEvent.pointerDown(channelCards[2]);
@@ -175,7 +162,7 @@ describe('Dashboard Channel Management Tests', () => {
     });
 
     it('should update active channel visual state', async () => {
-      const { container } = render(Dashboard);
+      const { container } = render(Dashboard, { props: { channelStore } });
       
       // Change active channel
       activeChannel.set(3);
@@ -190,7 +177,7 @@ describe('Dashboard Channel Management Tests', () => {
 
   describe('Real-time Updates', () => {
     it('should update when channel data changes', async () => {
-      const { getByText, queryByText } = render(Dashboard);
+      const { getByText, queryByText } = render(Dashboard, { props: { channelStore } });
       
       // Initially channel 2 is offline
       expect(queryByText('Channel 3')).toBeInTheDocument();
@@ -218,7 +205,7 @@ describe('Dashboard Channel Management Tests', () => {
     });
 
     it('should handle rapid channel updates', async () => {
-      const { getByText } = render(Dashboard);
+      const { getByText } = render(Dashboard, { props: { channelStore } });
       
       // Simulate rapid voltage changes on channel 0
       for (let i = 0; i < 10; i++) {
@@ -266,7 +253,7 @@ describe('Dashboard Channel Management Tests', () => {
         }))
       ]);
       
-      const { container } = render(Dashboard);
+      const { container } = render(Dashboard, { props: { channelStore } });
       
       // Should render without crashing
       expect(container.querySelector('.dashboard')).toBeInTheDocument();
@@ -276,7 +263,7 @@ describe('Dashboard Channel Management Tests', () => {
     it('should handle empty channel array', () => {
       channels.set([]);
       
-      const { container } = render(Dashboard);
+      const { container } = render(Dashboard, { props: { channelStore } });
       
       const channelCards = container.querySelectorAll('.channel-card');
       expect(channelCards.length).toBe(0);
@@ -297,7 +284,7 @@ describe('Dashboard Channel Management Tests', () => {
       
       channels.set(manyChannels);
       
-      const { container } = render(Dashboard);
+      const { container } = render(Dashboard, { props: { channelStore } });
       
       const channelCards = container.querySelectorAll('.channel-card');
       expect(channelCards.length).toBe(10);

--- a/mdp-webui/tests/components/Dashboard.test.js
+++ b/mdp-webui/tests/components/Dashboard.test.js
@@ -22,20 +22,14 @@ function createMockChannelStore() {
   };
 }
 
-var mockChannelStore;
-
-vi.mock('$lib/stores/channels', () => {
-  mockChannelStore = createMockChannelStore();
-  return { channelStore: mockChannelStore };
-});
-
 import Dashboard from '$lib/components/Dashboard.svelte';
-import { channelStore } from '$lib/stores/channels';
 
 describe('Dashboard Component', () => {
+  const channelStore = createMockChannelStore();
+
   beforeEach(() => {
     // Reset mock store to clean state
-    mockChannelStore.reset();
+    channelStore.reset();
     
     // Set up test data
     channelStore.channels.set(Array(6).fill(null).map((_, i) => ({
@@ -57,7 +51,7 @@ describe('Dashboard Component', () => {
   describe('Rendering', () => {
 
     it('should render all 6 channel cards', () => {
-      const { getAllByTestId } = render(Dashboard);
+      const { getAllByTestId } = render(Dashboard, { props: { channelStore } });
       
       const cards = getAllByTestId(/channel-card-\d/);
       expect(cards).toHaveLength(6);
@@ -70,7 +64,7 @@ describe('Dashboard Component', () => {
     });
 
     it('should highlight active channel', async () => {
-      const { getByTestId } = render(Dashboard);
+      const { getByTestId } = render(Dashboard, { props: { channelStore } });
       
       // Set channel 2 as active
       channelStore.activeChannel.set(2);
@@ -90,7 +84,7 @@ describe('Dashboard Component', () => {
     });
 
     it('should update when channels data changes', async () => {
-      const { rerender } = render(Dashboard);
+      const { rerender } = render(Dashboard, { props: { channelStore } });
       
       // Update channels with online status
       channelStore.channels.set(Array(6).fill(null).map((_, i) => ({
@@ -116,7 +110,7 @@ describe('Dashboard Component', () => {
 
   describe('Grid Layout', () => {
     it('should use CSS grid for layout', () => {
-      const { container } = render(Dashboard);
+      const { container } = render(Dashboard, { props: { channelStore } });
       
       const grid = container.querySelector('.channel-grid');
       expect(grid).toBeInTheDocument();
@@ -127,7 +121,7 @@ describe('Dashboard Component', () => {
     });
 
     it('should have responsive grid columns', () => {
-      const { container } = render(Dashboard);
+      const { container } = render(Dashboard, { props: { channelStore } });
       
       const grid = container.querySelector('.channel-grid');
       const styles = window.getComputedStyle(grid);
@@ -141,7 +135,7 @@ describe('Dashboard Component', () => {
     it('should emit selectChannel event when card is clicked', async () => {
       const selectHandler = vi.fn();
       const { getByTestId } = render(Dashboard, { 
-        props: { onselectchannel: selectHandler }
+        props: { channelStore, onselectchannel: selectHandler }
       });
       
       // Click channel 3
@@ -155,7 +149,7 @@ describe('Dashboard Component', () => {
     it('should handle multiple channel selections', async () => {
       const selections = [];
       const { getByTestId } = render(Dashboard, {
-        props: { onselectchannel: (channel) => selections.push(channel) }
+        props: { channelStore, onselectchannel: (channel) => selections.push(channel) }
       });
       
       // Click multiple channels
@@ -174,7 +168,7 @@ describe('Dashboard Component', () => {
       
       const selectHandler = vi.fn();
       const { getByTestId } = render(Dashboard, {
-        props: { onselectchannel: selectHandler }
+        props: { channelStore, onselectchannel: selectHandler }
       });
       
       // Click the already active channel
@@ -187,7 +181,7 @@ describe('Dashboard Component', () => {
 
   describe('Data Binding', () => {
     it('should react to store updates', async () => {
-      const { container } = render(Dashboard);
+      const { container } = render(Dashboard, { props: { channelStore } });
       
       // Initially 6 cards
       let cards = container.querySelectorAll('[data-testid^="channel-card-"]');
@@ -218,7 +212,7 @@ describe('Dashboard Component', () => {
     it('should handle empty channel array', async () => {
       channelStore.channels.set([]);
       
-      const { container } = render(Dashboard);
+      const { container } = render(Dashboard, { props: { channelStore } });
       
       const cards = container.querySelectorAll('[data-testid^="channel-card-"]');
       expect(cards).toHaveLength(0);
@@ -231,7 +225,7 @@ describe('Dashboard Component', () => {
         { channel: 2, online: true }
       ]);
       
-      const { container } = render(Dashboard);
+      const { container } = render(Dashboard, { props: { channelStore } });
       
       const cards = container.querySelectorAll('[data-testid^="channel-card-"]');
       expect(cards).toHaveLength(3);
@@ -240,7 +234,7 @@ describe('Dashboard Component', () => {
 
   describe('Performance', () => {
     it('should handle rapid active channel changes', async () => {
-      const { container } = render(Dashboard);
+      const { container } = render(Dashboard, { props: { channelStore } });
       
       // Rapidly change active channel
       for (let i = 0; i < 20; i++) {
@@ -257,7 +251,7 @@ describe('Dashboard Component', () => {
     });
 
     it('should efficiently update only changed channels', async () => {
-      const { rerender } = render(Dashboard);
+      const { rerender } = render(Dashboard, { props: { channelStore } });
       
       const initialChannels = Array(6).fill(null).map((_, i) => ({
         channel: i,
@@ -282,7 +276,7 @@ describe('Dashboard Component', () => {
 
   describe('Accessibility', () => {
     it('should have semantic HTML structure', () => {
-      const { container } = render(Dashboard);
+      const { container } = render(Dashboard, { props: { channelStore } });
       
       // Grid should be properly structured
       const grid = container.querySelector('.channel-grid');
@@ -292,7 +286,7 @@ describe('Dashboard Component', () => {
     it('should support keyboard navigation', async () => {
       const selectHandler = vi.fn();
       const { container } = render(Dashboard, {
-        props: { onselectchannel: selectHandler }
+        props: { channelStore, onselectchannel: selectHandler }
       });
       
       // Get first card and simulate keyboard interaction
@@ -324,7 +318,7 @@ describe('Dashboard Component', () => {
         }
       ]);
       
-      const { getAllByTestId } = render(Dashboard);
+      const { getAllByTestId } = render(Dashboard, { props: { channelStore } });
       
       const cards = getAllByTestId(/channel-card-\d/);
       expect(cards).toHaveLength(3);
@@ -335,7 +329,7 @@ describe('Dashboard Component', () => {
         { channel: 999, online: true }
       ]);
       
-      const { getByTestId } = render(Dashboard);
+      const { getByTestId } = render(Dashboard, { props: { channelStore } });
       
       const card = getByTestId('channel-card-999');
       expect(card).toHaveTextContent('Channel 1000');
@@ -346,7 +340,7 @@ describe('Dashboard Component', () => {
         { channel: -1, online: true }
       ]);
       
-      const { getByTestId } = render(Dashboard);
+      const { getByTestId } = render(Dashboard, { props: { channelStore } });
       
       const card = getByTestId('channel-card--1');
       expect(card).toHaveTextContent('Channel 0');
@@ -355,14 +349,14 @@ describe('Dashboard Component', () => {
 
   describe('Memory Management', () => {
     it('should clean up event listeners on unmount', () => {
-      const { unmount } = render(Dashboard);
+      const { unmount } = render(Dashboard, { props: { channelStore } });
       
       // Should not throw errors
       expect(() => unmount()).not.toThrow();
     });
 
     it('should unsubscribe from stores on unmount', async () => {
-      const { unmount } = render(Dashboard);
+      const { unmount } = render(Dashboard, { props: { channelStore } });
       
       unmount();
       

--- a/mdp-webui/tests/components/OutputButton.test.js
+++ b/mdp-webui/tests/components/OutputButton.test.js
@@ -2,18 +2,12 @@ import { render, fireEvent, screen, waitFor } from '@testing-library/svelte';
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import OutputButton from '../../src/lib/components/OutputButton.svelte';
 
-// Mock the channel store
-const mockSetOutput = vi.hoisted(() => vi.fn());
-vi.mock('../../src/lib/stores/channels.js', () => ({
-  channelStore: {
-    setOutput: mockSetOutput
-  }
-}));
+const mockOnToggle = vi.hoisted(() => vi.fn());
 
 describe('OutputButton', () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    mockSetOutput.mockClear();
+    mockOnToggle.mockClear();
   });
 
   afterEach(() => {
@@ -27,7 +21,8 @@ describe('OutputButton', () => {
         props: {
           channel: 0,
           isOutput: false,
-          machineType: 'P906 PSU'
+          machineType: 'P906 PSU',
+          onToggle: mockOnToggle
         }
       });
 
@@ -39,7 +34,8 @@ describe('OutputButton', () => {
         props: {
           channel: 0,
           isOutput: false,
-          machineType: 'L1060 Load'
+          machineType: 'L1060 Load',
+          onToggle: mockOnToggle
         }
       });
 
@@ -51,7 +47,8 @@ describe('OutputButton', () => {
         props: {
           channel: 0,
           isOutput: false,
-          machineType: 'L1060'
+          machineType: 'L1060',
+          onToggle: mockOnToggle
         }
       });
 
@@ -63,7 +60,8 @@ describe('OutputButton', () => {
         props: {
           channel: 0,
           isOutput: false,
-          machineType: 'Unknown'
+          machineType: 'Unknown',
+          onToggle: mockOnToggle
         }
       });
 
@@ -77,7 +75,8 @@ describe('OutputButton', () => {
         props: {
           channel: 0,
           isOutput: true,
-          machineType: 'P906 PSU'
+          machineType: 'P906 PSU',
+          onToggle: mockOnToggle
         }
       });
 
@@ -90,7 +89,8 @@ describe('OutputButton', () => {
         props: {
           channel: 0,
           isOutput: false,
-          machineType: 'P906 PSU'
+          machineType: 'P906 PSU',
+          onToggle: mockOnToggle
         }
       });
 
@@ -106,6 +106,7 @@ describe('OutputButton', () => {
           channel: 0,
           isOutput: false,
           machineType: 'P906 PSU',
+          onToggle: mockOnToggle,
           size: 'small'
         }
       });
@@ -119,6 +120,7 @@ describe('OutputButton', () => {
           channel: 0,
           isOutput: false,
           machineType: 'P906 PSU',
+          onToggle: mockOnToggle,
           size: 'normal'
         }
       });
@@ -129,13 +131,14 @@ describe('OutputButton', () => {
 
   describe('Optimistic State Updates', () => {
     it('should immediately show new state when clicked', async () => {
-      mockSetOutput.mockResolvedValue();
+      mockOnToggle.mockResolvedValue();
 
       render(OutputButton, {
         props: {
           channel: 0,
           isOutput: false,
-          machineType: 'P906 PSU'
+          machineType: 'P906 PSU',
+          onToggle: mockOnToggle
         }
       });
 
@@ -153,29 +156,31 @@ describe('OutputButton', () => {
     });
 
     it('should call channelStore.setOutput with correct parameters', async () => {
-      mockSetOutput.mockResolvedValue();
+      mockOnToggle.mockResolvedValue();
 
       render(OutputButton, {
         props: {
           channel: 2,
           isOutput: false,
-          machineType: 'P906 PSU'
+          machineType: 'P906 PSU',
+          onToggle: mockOnToggle
         }
       });
 
       await fireEvent.pointerUp(screen.getByRole('button'));
 
-      expect(mockSetOutput).toHaveBeenCalledWith(2, true);
+      expect(mockOnToggle).toHaveBeenCalledWith(2, true);
     });
 
     it('should toggle from ON to OFF state', async () => {
-      mockSetOutput.mockResolvedValue();
+      mockOnToggle.mockResolvedValue();
 
       render(OutputButton, {
         props: {
           channel: 0,
           isOutput: true,
-          machineType: 'P906 PSU'
+          machineType: 'P906 PSU',
+          onToggle: mockOnToggle
         }
       });
 
@@ -186,20 +191,21 @@ describe('OutputButton', () => {
 
       expect(screen.getByText('Output: OFF')).toBeInTheDocument();
       expect(button).not.toHaveClass('on');
-      expect(mockSetOutput).toHaveBeenCalledWith(0, false);
+      expect(mockOnToggle).toHaveBeenCalledWith(0, false);
     });
   });
 
   describe('Timeout and Error Handling', () => {
     it('should revert to original state after 5 second timeout', async () => {
       // Mock a hanging promise (no acknowledgement)
-      mockSetOutput.mockReturnValue(new Promise(() => {}));
+      mockOnToggle.mockReturnValue(new Promise(() => {}));
 
       render(OutputButton, {
         props: {
           channel: 0,
           isOutput: false,
-          machineType: 'P906 PSU'
+          machineType: 'P906 PSU',
+          onToggle: mockOnToggle
         }
       });
 
@@ -223,13 +229,14 @@ describe('OutputButton', () => {
 
     it('should revert state immediately on setOutput error', async () => {
       const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
-      mockSetOutput.mockRejectedValue(new Error('Communication failed'));
+      mockOnToggle.mockRejectedValue(new Error('Communication failed'));
 
       render(OutputButton, {
         props: {
           channel: 0,
           isOutput: false,
-          machineType: 'P906 PSU'
+          machineType: 'P906 PSU',
+          onToggle: mockOnToggle
         }
       });
 
@@ -249,13 +256,14 @@ describe('OutputButton', () => {
     });
 
     it('should clear optimistic state when actual state matches', async () => {
-      mockSetOutput.mockResolvedValue();
+      mockOnToggle.mockResolvedValue();
 
       const { rerender } = render(OutputButton, {
         props: {
           channel: 0,
           isOutput: false,
-          machineType: 'P906 PSU'
+          machineType: 'P906 PSU',
+          onToggle: mockOnToggle
         }
       });
 
@@ -269,7 +277,8 @@ describe('OutputButton', () => {
       await rerender({
         channel: 0,
         isOutput: true,
-        machineType: 'P906 PSU'
+        machineType: 'P906 PSU',
+        onToggle: mockOnToggle
       });
 
       // Should clear waiting state
@@ -288,6 +297,7 @@ describe('OutputButton', () => {
           channel: 0,
           isOutput: false,
           machineType: 'P906 PSU',
+          onToggle: mockOnToggle,
           disabled: true
         }
       });
@@ -297,18 +307,19 @@ describe('OutputButton', () => {
 
       await fireEvent.pointerUp(button);
 
-      expect(mockSetOutput).not.toHaveBeenCalled();
+      expect(mockOnToggle).not.toHaveBeenCalled();
       expect(screen.getByText('Output: OFF')).toBeInTheDocument();
     });
 
     it('should not respond to clicks while waiting for acknowledgement', async () => {
-      mockSetOutput.mockReturnValue(new Promise(() => {}));
+      mockOnToggle.mockReturnValue(new Promise(() => {}));
 
       render(OutputButton, {
         props: {
           channel: 0,
           isOutput: false,
-          machineType: 'P906 PSU'
+          machineType: 'P906 PSU',
+          onToggle: mockOnToggle
         }
       });
 
@@ -316,49 +327,51 @@ describe('OutputButton', () => {
       
       // First click
       await fireEvent.pointerUp(button);
-      expect(mockSetOutput).toHaveBeenCalledTimes(1);
+      expect(mockOnToggle).toHaveBeenCalledTimes(1);
       expect(button).toHaveClass('waiting');
 
       // Second click should be ignored
       await fireEvent.pointerUp(button);
-      expect(mockSetOutput).toHaveBeenCalledTimes(1);
+      expect(mockOnToggle).toHaveBeenCalledTimes(1);
     });
   });
 
   describe('Event Propagation', () => {
     it('should call setOutput when clicked', async () => {
-      mockSetOutput.mockResolvedValue();
+      mockOnToggle.mockResolvedValue();
 
       render(OutputButton, {
         props: {
           channel: 0,
           isOutput: false,
-          machineType: 'P906 PSU'
+          machineType: 'P906 PSU',
+          onToggle: mockOnToggle
         }
       });
 
       const button = screen.getByRole('button');
       await fireEvent.pointerUp(button);
 
-      expect(mockSetOutput).toHaveBeenCalled();
+      expect(mockOnToggle).toHaveBeenCalled();
     });
   });
 
   describe('Event Emission', () => {
     it('should successfully toggle without timing out', async () => {
-      mockSetOutput.mockResolvedValue();
+      mockOnToggle.mockResolvedValue();
 
       render(OutputButton, {
         props: {
           channel: 2,
           isOutput: false,
-          machineType: 'P906 PSU'
+          machineType: 'P906 PSU',
+          onToggle: mockOnToggle
         }
       });
 
       await fireEvent.pointerUp(screen.getByRole('button'));
 
-      expect(mockSetOutput).toHaveBeenCalledWith(2, true);
+      expect(mockOnToggle).toHaveBeenCalledWith(2, true);
     });
   });
 });

--- a/mdp-webui/tests/components/Sparkline.test.js
+++ b/mdp-webui/tests/components/Sparkline.test.js
@@ -33,13 +33,10 @@ vi.mock('$lib/stores/theme.js', () => ({
   theme: writable('light')
 }));
 
-// Mock sparkline store
 const mockSparklineData = writable([]);
-vi.mock('$lib/stores/sparkline.js', () => ({
-  sparklineStore: {
-    getChannelMetricData: vi.fn(() => mockSparklineData)
-  }
-}));
+const mockSparklineStore = {
+  getChannelMetricData: vi.fn(() => mockSparklineData),
+};
 
 import Sparkline from '$lib/components/Sparkline.svelte';
 
@@ -57,6 +54,7 @@ describe('Sparkline Component', () => {
         props: { 
           channel: 0, 
           metric: 'voltage',
+          sparklineStore: mockSparklineStore,
           width: 300,
           height: 80
         }
@@ -74,7 +72,8 @@ describe('Sparkline Component', () => {
       const { container } = render(Sparkline, {
         props: { 
           channel: 0, 
-          metric: 'voltage'
+          metric: 'voltage',
+          sparklineStore: mockSparklineStore
         }
       });
       
@@ -126,7 +125,7 @@ describe('Sparkline Component', () => {
       mockSparklineData.set(mockData);
       
       render(Sparkline, {
-        props: { channel: 0, metric: 'voltage' }
+        props: { channel: 0, metric: 'voltage', sparklineStore: mockSparklineStore }
       });
       
       await waitFor(() => {
@@ -140,7 +139,7 @@ describe('Sparkline Component', () => {
       mockSparklineData.set(mockData);
       
       const { rerender, container } = render(Sparkline, {
-        props: { channel: 0, metric: 'voltage' }
+        props: { channel: 0, metric: 'voltage', sparklineStore: mockSparklineStore }
       });
       
       await waitFor(() => {
@@ -149,7 +148,7 @@ describe('Sparkline Component', () => {
       });
       
       // Test current metric - should still render properly
-      await rerender({ channel: 0, metric: 'current' });
+      await rerender({ channel: 0, metric: 'current', sparklineStore: mockSparklineStore });
       
       await waitFor(() => {
         expect(container.querySelector('svg')).toBeInTheDocument();
@@ -162,7 +161,7 @@ describe('Sparkline Component', () => {
       mockSparklineData.set(mockData);
       
       render(Sparkline, {
-        props: { channel: 0, metric: 'voltage' }
+        props: { channel: 0, metric: 'voltage', sparklineStore: mockSparklineStore }
       });
       
       await waitFor(() => {
@@ -189,7 +188,7 @@ describe('Sparkline Component', () => {
       mockSparklineData.set(smallData);
       
       render(Sparkline, {
-        props: { channel: 0, metric: 'voltage' }
+        props: { channel: 0, metric: 'voltage', sparklineStore: mockSparklineStore }
       });
       
       await waitFor(() => {
@@ -209,7 +208,7 @@ describe('Sparkline Component', () => {
       mockSparklineData.set(largeData);
       
       render(Sparkline, {
-        props: { channel: 0, metric: 'voltage' }
+        props: { channel: 0, metric: 'voltage', sparklineStore: mockSparklineStore }
       });
       
       await waitFor(() => {
@@ -234,6 +233,7 @@ describe('Sparkline Component', () => {
         props: { 
           channel: 0, 
           metric: 'voltage',
+          sparklineStore: mockSparklineStore,
           targetValue: 3.5 
         }
       });
@@ -261,6 +261,7 @@ describe('Sparkline Component', () => {
         props: { 
           channel: 0, 
           metric: 'voltage',
+          sparklineStore: mockSparklineStore,
           targetValue: null
         }
       });
@@ -280,6 +281,7 @@ describe('Sparkline Component', () => {
         props: { 
           channel: 0, 
           metric: 'voltage',
+          sparklineStore: mockSparklineStore,
           targetValue: 0
         }
       });
@@ -303,7 +305,7 @@ describe('Sparkline Component', () => {
       mockSparklineData.set(mockData);
       
       render(Sparkline, {
-        props: { channel: 0, metric: 'voltage' }
+        props: { channel: 0, metric: 'voltage', sparklineStore: mockSparklineStore }
       });
       
       await waitFor(() => {
@@ -323,6 +325,7 @@ describe('Sparkline Component', () => {
         props: { 
           channel: 0, 
           metric: 'voltage',
+          sparklineStore: mockSparklineStore,
           showAxes: true
         }
       });
@@ -352,6 +355,7 @@ describe('Sparkline Component', () => {
           props: { 
             channel: 0, 
             metric,
+            sparklineStore: mockSparklineStore,
             showAxes: true
           }
         });
@@ -378,7 +382,7 @@ describe('Sparkline Component', () => {
       mockSparklineData.set(initialData);
       
       const { container } = render(Sparkline, {
-        props: { channel: 0, metric: 'voltage' }
+        props: { channel: 0, metric: 'voltage', sparklineStore: mockSparklineStore }
       });
       
       await waitFor(() => {
@@ -405,7 +409,7 @@ describe('Sparkline Component', () => {
       ]);
       
       const { rerender, container } = render(Sparkline, {
-        props: { channel: 0, metric: 'voltage' }
+        props: { channel: 0, metric: 'voltage', sparklineStore: mockSparklineStore }
       });
       
       await waitFor(() => {
@@ -413,7 +417,7 @@ describe('Sparkline Component', () => {
         expect(container.querySelector('svg')).toBeInTheDocument();
       });
       
-      await rerender({ channel: 0, metric: 'current' });
+      await rerender({ channel: 0, metric: 'current', sparklineStore: mockSparklineStore });
       
       // Chart should still be present after metric change
       expect(container.querySelector('svg')).toBeInTheDocument();
@@ -432,7 +436,7 @@ describe('Sparkline Component', () => {
       mockSparklineData.set(mockData);
       
       render(Sparkline, {
-        props: { channel: 0, metric: 'voltage' }
+        props: { channel: 0, metric: 'voltage', sparklineStore: mockSparklineStore }
       });
       
       await waitFor(() => {
@@ -454,6 +458,7 @@ describe('Sparkline Component', () => {
         props: { 
           channel: 0, 
           metric: 'voltage',
+          sparklineStore: mockSparklineStore,
           showTooltip: false
         }
       });

--- a/mdp-webui/tests/integration/recording-flow.test.js
+++ b/mdp-webui/tests/integration/recording-flow.test.js
@@ -128,6 +128,12 @@ import App from '../../src/App.svelte';
 import { serialConnection } from '$lib/serial';
 import { channelStore } from '$lib/stores/channels';
 
+const runtime = {
+  serial: serialConnection,
+  channels: channelStore,
+  destroy: vi.fn(),
+};
+
 // Mock URL.createObjectURL for file export
 global.URL.createObjectURL = vi.fn(() => 'mock-url');
 global.URL.revokeObjectURL = vi.fn();
@@ -227,7 +233,7 @@ describe('Recording Flow Integration Test', () => {
   it.skip('should complete full recording workflow', async () => {
     // SKIP REASON: Complex integration between wave packet processing and channel store updates
     // The test passes individual steps but waveform data accumulation requires full app integration
-    const renderResult = render(App);
+    const renderResult = render(App, { props: { runtime } });
     const { container, getByText, queryByText } = renderResult;
     
     // Step 1: Connect to device
@@ -344,7 +350,7 @@ describe('Recording Flow Integration Test', () => {
   });
 
   it('should handle channel switching during recording', async () => {
-    const renderResult = render(App);
+    const renderResult = render(App, { props: { runtime } });
     const { container, getByText, queryByText } = renderResult;
     
     await connectDevice(renderResult);
@@ -396,7 +402,7 @@ describe('Recording Flow Integration Test', () => {
   });
 
   it('should handle errors during recording', async () => {
-    const renderResult = render(App);
+    const renderResult = render(App, { props: { runtime } });
     const { container, getByText, queryByText } = renderResult;
     
     await connectDevice(renderResult);
@@ -432,7 +438,7 @@ describe('Recording Flow Integration Test', () => {
   it.skip('should export valid CSV format', async () => {
     // SKIP REASON: Depends on waveform data accumulation which requires full app integration
     // Export button only appears when there's recorded data
-    const renderResult = render(App);
+    const renderResult = render(App, { props: { runtime } });
     const { container, getByText, queryByText } = renderResult;
     
     await connectDevice(renderResult);
@@ -468,7 +474,7 @@ describe('Recording Flow Integration Test', () => {
   });
 
   it('should handle empty recording export', async () => {
-    const renderResult = render(App);
+    const renderResult = render(App, { props: { runtime } });
     const { container, getByText, queryByText } = renderResult;
     
     await connectDevice(renderResult);
@@ -490,7 +496,7 @@ describe('Recording Flow Integration Test', () => {
   });
 
   it('should update active channel from device', async () => {
-    const renderResult = render(App);
+    const renderResult = render(App, { props: { runtime } });
     const { container } = renderResult;
     
     await connectDevice(renderResult);

--- a/mdp-webui/tests/integration/serial-flow.test.js
+++ b/mdp-webui/tests/integration/serial-flow.test.js
@@ -130,6 +130,13 @@ vi.mock('$lib/stores/channels', () => {
 const App = (await import('../../src/App.svelte')).default;
 const { channelStore } = await import('$lib/stores/channels');
 const serialConnection = sharedTestConnection;
+const runtime = {
+  serial: serialConnection,
+  channels: channelStore,
+  timeseries: {},
+  timeseriesIntegration: {},
+  destroy: vi.fn(),
+};
 
 describe('Serial Communication Flow Integration Test', () => {
   let mockSerial;
@@ -160,14 +167,9 @@ describe('Serial Communication Flow Integration Test', () => {
     serialConnection.clearPacketHandlers();
   });
 
-  describe('Full Connection Flow', () => {
-    it('should complete connection handshake sequence', async () => {
-      const { getByText } = render(App, {
-        props: {
-          serialConnection,
-          channelStore
-        }
-      });
+	  describe('Full Connection Flow', () => {
+	    it('should complete connection handshake sequence', async () => {
+	      const { getByText } = render(App, { props: { runtime } });
       
       mockPort = new MockSerialPort();
       mockSerial.setNextPort(mockPort);
@@ -215,16 +217,11 @@ describe('Serial Communication Flow Integration Test', () => {
       });
     });
 
-    it('should maintain heartbeat during connection', async () => {
+	    it('should maintain heartbeat during connection', async () => {
       // This test needs fake timers to control heartbeat timing
       vi.useFakeTimers();
       
-      const { getByText } = render(App, {
-        props: {
-          serialConnection,
-          channelStore
-        }
-      });
+	      const { getByText } = render(App, { props: { runtime } });
       
       mockPort = new MockSerialPort();
       mockSerial.setNextPort(mockPort);
@@ -252,14 +249,9 @@ describe('Serial Communication Flow Integration Test', () => {
     });
   });
 
-  describe('Command and Response Flow', () => {
-    it('should send commands and process responses', async () => {
-      const { getByText, getByTestId } = render(App, {
-        props: {
-          serialConnection,
-          channelStore
-        }
-      });
+	  describe('Command and Response Flow', () => {
+	    it('should send commands and process responses', async () => {
+	      const { getByText, getByTestId } = render(App, { props: { runtime } });
       
       mockPort = new MockSerialPort();
       mockSerial.setNextPort(mockPort);
@@ -323,13 +315,8 @@ describe('Serial Communication Flow Integration Test', () => {
       }
     });
 
-    it('should handle channel switching via device', async () => {
-      const { getByText } = render(App, {
-        props: {
-          serialConnection,
-          channelStore
-        }
-      });
+	    it('should handle channel switching via device', async () => {
+	      const { getByText } = render(App, { props: { runtime } });
       
       mockPort = new MockSerialPort();
       mockSerial.setNextPort(mockPort);
@@ -404,13 +391,8 @@ describe('Serial Communication Flow Integration Test', () => {
       expect(receivedDeviceType).toEqual({ type: 'M01', haveLcd: true });
     });
 
-    it('should handle error 240 packet', async () => {
-      const { getByText } = render(App, {
-        props: {
-          serialConnection,
-          channelStore
-        }
-      });
+	    it('should handle error 240 packet', async () => {
+	      const { getByText } = render(App, { props: { runtime } });
       
       mockPort = new MockSerialPort();
       mockSerial.setNextPort(mockPort);
@@ -430,13 +412,8 @@ describe('Serial Communication Flow Integration Test', () => {
       expect(getByText('Connected')).toBeInTheDocument();
     });
 
-    it('should recover from disconnection', async () => {
-      const { getByText } = render(App, {
-        props: {
-          serialConnection,
-          channelStore
-        }
-      });
+	    it('should recover from disconnection', async () => {
+	      const { getByText } = render(App, { props: { runtime } });
       
       mockPort = new MockSerialPort();
       mockSerial.setNextPort(mockPort);
@@ -476,14 +453,9 @@ describe('Serial Communication Flow Integration Test', () => {
     });
   });
 
-  describe('Packet Buffering and Processing', () => {
-    it('should handle multiple packets in one read', async () => {
-      const { getByText } = render(App, {
-        props: {
-          serialConnection,
-          channelStore
-        }
-      });
+	  describe('Packet Buffering and Processing', () => {
+	    it('should handle multiple packets in one read', async () => {
+	      const { getByText } = render(App, { props: { runtime } });
       
       mockPort = new MockSerialPort();
       mockSerial.setNextPort(mockPort);
@@ -508,13 +480,8 @@ describe('Serial Communication Flow Integration Test', () => {
       });
     });
 
-    it('should handle partial packet reception', async () => {
-      const { getByText } = render(App, {
-        props: {
-          serialConnection,
-          channelStore
-        }
-      });
+	    it('should handle partial packet reception', async () => {
+	      const { getByText } = render(App, { props: { runtime } });
       
       mockPort = new MockSerialPort();
       mockSerial.setNextPort(mockPort);
@@ -545,13 +512,8 @@ describe('Serial Communication Flow Integration Test', () => {
       });
     });
 
-    it('should skip garbage data and find valid packets', async () => {
-      const { getByText } = render(App, {
-        props: {
-          serialConnection,
-          channelStore
-        }
-      });
+	    it('should skip garbage data and find valid packets', async () => {
+	      const { getByText } = render(App, { props: { runtime } });
       
       mockPort = new MockSerialPort();
       mockSerial.setNextPort(mockPort);
@@ -581,14 +543,9 @@ describe('Serial Communication Flow Integration Test', () => {
     });
   });
 
-  describe('Address Configuration Flow', () => {
-    it('should receive and process address information', async () => {
-      const { getByText } = render(App, {
-        props: {
-          serialConnection,
-          channelStore
-        }
-      });
+	  describe('Address Configuration Flow', () => {
+	    it('should receive and process address information', async () => {
+	      const { getByText } = render(App, { props: { runtime } });
       
       mockPort = new MockSerialPort();
       mockSerial.setNextPort(mockPort);
@@ -615,14 +572,9 @@ describe('Serial Communication Flow Integration Test', () => {
     });
   });
 
-  describe('Performance and Stress Testing', () => {
-    it('should handle rapid packet reception', async () => {
-      const { getByText } = render(App, {
-        props: {
-          serialConnection,
-          channelStore
-        }
-      });
+	  describe('Performance and Stress Testing', () => {
+	    it('should handle rapid packet reception', async () => {
+	      const { getByText } = render(App, { props: { runtime } });
       
       mockPort = new MockSerialPort();
       mockSerial.setNextPort(mockPort);
@@ -646,13 +598,8 @@ describe('Serial Communication Flow Integration Test', () => {
       });
     });
 
-    it('should handle very large single packet', async () => {
-      const { getByText } = render(App, {
-        props: {
-          serialConnection,
-          channelStore
-        }
-      });
+	    it('should handle very large single packet', async () => {
+	      const { getByText } = render(App, { props: { runtime } });
       
       mockPort = new MockSerialPort();
       mockSerial.setNextPort(mockPort);
@@ -688,14 +635,9 @@ describe('Serial Communication Flow Integration Test', () => {
     });
   });
 
-  describe('State Synchronization', () => {
-    it('should maintain consistent state between device and UI', async () => {
-      const { getByText } = render(App, {
-        props: {
-          serialConnection,
-          channelStore
-        }
-      });
+	  describe('State Synchronization', () => {
+	    it('should maintain consistent state between device and UI', async () => {
+	      const { getByText } = render(App, { props: { runtime } });
       
       mockPort = new MockSerialPort();
       mockSerial.setNextPort(mockPort);

--- a/mdp-webui/tests/integration/sparkline-integration.test.js
+++ b/mdp-webui/tests/integration/sparkline-integration.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, waitFor } from '@testing-library/svelte';
 import { tick } from 'svelte';
-import { get } from 'svelte/store';
+import { get, writable } from 'svelte/store';
 
 // Mock Observable Plot
 vi.mock('@observablehq/plot', () => {
@@ -23,194 +23,158 @@ vi.mock('@observablehq/plot', () => {
       plot: mockPlot,
       lineY: vi.fn((data, options) => ({ type: 'lineY', data, options })),
       dot: vi.fn((data, options) => ({ type: 'dot', data, options })),
-      ruleY: vi.fn((data, options) => ({ type: 'ruleY', data, options }))
-    }
+      ruleY: vi.fn((data, options) => ({ type: 'ruleY', data, options })),
+    },
   };
 });
 
-// Import mock helpers
-import { createSynthesizePacket } from '../helpers/mock-packet-factory.js';
-
-// Import the real stores and components
 import Sparkline from '$lib/components/Sparkline.svelte';
-import { sparklineStore } from '$lib/stores/sparkline.js';
-import { channelStore } from '$lib/stores/channels.js';
+import { createSparklineStore } from '$lib/stores/sparkline.js';
+
+function createChannelStoreStub() {
+  const initial = Array.from({ length: 6 }, (_, i) => ({
+    channel: i,
+    online: false,
+    machineType: 'Unknown',
+    voltage: 0,
+    current: 0,
+    power: 0,
+    temperature: 0,
+    isOutput: false,
+    mode: 'Normal',
+    address: [0, 0, 0, 0, 0],
+    targetVoltage: 0,
+    targetCurrent: 0,
+    targetPower: 0,
+    recording: false,
+    waveformData: [],
+  }));
+
+  const channels = writable(initial);
+
+  return {
+    channels,
+    reset: () => channels.set(initial),
+  };
+}
 
 describe('Sparkline Integration with Channel Store', () => {
+  let channelStore;
+  let sparklineStore;
+
   beforeEach(() => {
     vi.clearAllMocks();
-    
-    // Reset stores
-    channelStore.reset();
-    sparklineStore.clear();
-    
-    // Use fake timers for controlled testing
     vi.useFakeTimers();
+
+    channelStore = createChannelStoreStub();
+    sparklineStore = createSparklineStore({ channels: channelStore.channels });
+    sparklineStore.clear();
   });
 
   afterEach(() => {
+    sparklineStore.destroy();
     vi.useRealTimers();
   });
 
-  it('should update sparkline data when Synthesize packets are processed', async () => {
-    // Create a sparkline component for channel 0, voltage metric
-    const { container } = render(Sparkline, {
+  it('updates sparkline data when channel measurements change', async () => {
+    const Plot = await import('@observablehq/plot');
+
+    render(Sparkline, {
       props: {
         channel: 0,
         metric: 'voltage',
         width: 200,
-        height: 60
-      }
+        height: 60,
+        sparklineStore,
+      },
     });
 
-    // Initially should show no data
-    // Note: Skipping no-data div check due to Svelte conditional rendering issues in test environment
-    await tick();
-
-    // Create a mock Synthesize packet with channel data
-    const mockChannelData = [
-      {
-        channel: 0,
+    channelStore.channels.update((channels) => {
+      channels[0] = {
+        ...channels[0],
         online: true,
         voltage: 3.3,
         current: 0.5,
         temperature: 25.0,
         machineType: 'P906',
         isOutput: false,
-        mode: 'Normal'
-      },
-      // Other channels (offline)
-      ...Array(5).fill(null).map((_, i) => ({
-        channel: i + 1,
-        online: false,
-        voltage: 0,
-        current: 0,
-        temperature: 0,
-        machineType: 'Unknown',
-        isOutput: false,
-        mode: 'Normal'
-      }))
-    ];
-
-    // Create and send a Synthesize packet
-    const synthesizePacket = createSynthesizePacket(mockChannelData);
-    
-    // Get the channel store's Synthesize handler
-    const Plot = await import('@observablehq/plot');
-    
-    // Process the packet through the channel store
-    // Note: This simulates what happens when a real packet arrives
-    const mockPacketHandlers = new Map();
-    const originalRegisterHandler = channelStore.channels.subscribe;
-    
-    // Manually trigger the synthesize handler like the serial connection would
-    const processedData = mockChannelData;
-    
-    // Update channel store directly (simulating successful packet processing)
-    channelStore.channels.update(channels => {
-      processedData.forEach((data, i) => {
-        channels[i] = { ...channels[i], ...data };
-      });
+      };
       return channels;
     });
 
-    // Wait for reactivity to propagate
     await tick();
-    
-    // Advance time to allow sparkline store to process the update
     vi.advanceTimersByTime(100);
     await tick();
 
-    // Check that sparkline data store has been updated
     const sparklineData = get(sparklineStore.data);
-    expect(sparklineData[0]).toBeDefined();
-    expect(sparklineData[0].voltage).toBeDefined();
-    expect(sparklineData[0].voltage.length).toBeGreaterThan(0);
-    
-    // Check that the latest voltage value matches
-    const latestVoltagePoint = sparklineData[0].voltage[sparklineData[0].voltage.length - 1];
-    expect(latestVoltagePoint.value).toBe(3.3);
+    expect(sparklineData[0]?.voltage?.length).toBeGreaterThan(0);
 
-    // Verify the plot was created
+    const latest = sparklineData[0].voltage[sparklineData[0].voltage.length - 1];
+    expect(latest.value).toBe(3.3);
+
     await waitFor(() => {
       expect(Plot.plot).toHaveBeenCalled();
     });
   });
 
-  it('should handle multiple channel updates over time', async () => {
-    const { container } = render(Sparkline, {
+  it('handles multiple updates over time', async () => {
+    render(Sparkline, {
       props: {
         channel: 0,
         metric: 'current',
         width: 200,
-        height: 60
-      }
+        height: 60,
+        sparklineStore,
+      },
     });
 
-    const Plot = await import('@observablehq/plot');
-
-    // Send multiple updates with different current values
     const updates = [
       { voltage: 3.3, current: 0.5 },
       { voltage: 3.4, current: 0.6 },
-      { voltage: 3.2, current: 0.4 }
+      { voltage: 3.2, current: 0.4 },
     ];
 
-    for (let i = 0; i < updates.length; i++) {
-      const update = updates[i];
-      
-      // Update channel store
-      channelStore.channels.update(channels => {
+    for (const update of updates) {
+      channelStore.channels.update((channels) => {
         channels[0] = {
           ...channels[0],
           online: true,
           voltage: update.voltage,
           current: update.current,
           temperature: 25.0,
-          machineType: 'P906'
+          machineType: 'P906',
         };
         return channels;
       });
 
-      // Advance time between updates
-      vi.advanceTimersByTime(1000); // 1 second
+      vi.advanceTimersByTime(1000);
       await tick();
     }
 
-    // Check that we have multiple data points
     const sparklineData = get(sparklineStore.data);
-    expect(sparklineData[0].current.length).toBe(3);
-    
-    // Verify the values are correct
-    const currentValues = sparklineData[0].current.map(point => point.value);
-    expect(currentValues).toEqual([0.5, 0.6, 0.4]);
-
-    // Verify timestamps are in ascending order
-    const timestamps = sparklineData[0].current.map(point => point.timestamp);
-    for (let i = 1; i < timestamps.length; i++) {
-      expect(timestamps[i]).toBeGreaterThan(timestamps[i - 1]);
-    }
+    expect(sparklineData[0]?.current?.length).toBe(3);
+    expect(sparklineData[0].current.map((p) => p.value)).toEqual([0.5, 0.6, 0.4]);
   });
 
-  it('should calculate power metric correctly from voltage and current', async () => {
-    const { container } = render(Sparkline, {
+  it('calculates power metric from voltage and current', async () => {
+    render(Sparkline, {
       props: {
         channel: 1,
         metric: 'power',
         width: 200,
-        height: 60
-      }
+        height: 60,
+        sparklineStore,
+      },
     });
 
-    // Update channel 1 with voltage and current
-    channelStore.channels.update(channels => {
+    channelStore.channels.update((channels) => {
       channels[1] = {
         ...channels[1],
         online: true,
         voltage: 5.0,
         current: 1.2,
         temperature: 30.0,
-        machineType: 'P906'
+        machineType: 'P906',
       };
       return channels;
     });
@@ -219,43 +183,38 @@ describe('Sparkline Integration with Channel Store', () => {
     vi.advanceTimersByTime(100);
     await tick();
 
-    // Check that power was calculated correctly (5.0V * 1.2A = 6.0W)
     const sparklineData = get(sparklineStore.data);
-    expect(sparklineData[1]).toBeDefined();
-    expect(sparklineData[1].power).toBeDefined();
-    expect(sparklineData[1].power.length).toBeGreaterThan(0);
-    
-    const latestPowerPoint = sparklineData[1].power[sparklineData[1].power.length - 1];
-    expect(latestPowerPoint.value).toBe(6.0);
+    expect(sparklineData[1]?.power?.length).toBeGreaterThan(0);
+
+    const latest = sparklineData[1].power[sparklineData[1].power.length - 1];
+    expect(latest.value).toBe(6.0);
   });
 
-  it('should maintain 1-minute sliding window', async () => {
-    const { container } = render(Sparkline, {
+  it('maintains a 1-minute sliding window', async () => {
+    render(Sparkline, {
       props: {
         channel: 0,
         metric: 'voltage',
         width: 200,
-        height: 60
-      }
+        height: 60,
+        sparklineStore,
+      },
     });
 
-    // Set a fixed starting time for consistency
-    const startTime = 1000000; // Fixed timestamp
+    const startTime = 1000000;
     vi.setSystemTime(startTime);
-    
+
     for (let i = 0; i < 10; i++) {
-      // Update timestamp for each iteration
-      vi.setSystemTime(startTime + (i * 10000)); // 10 seconds apart
-      
-      // Add data point
-      channelStore.channels.update(channels => {
+      vi.setSystemTime(startTime + i * 10000);
+
+      channelStore.channels.update((channels) => {
         channels[0] = {
           ...channels[0],
           online: true,
-          voltage: 3.0 + (i * 0.1),
+          voltage: 3.0 + i * 0.1,
           current: 0.5,
           temperature: 25.0,
-          machineType: 'P906'
+          machineType: 'P906',
         };
         return channels;
       });
@@ -263,48 +222,39 @@ describe('Sparkline Integration with Channel Store', () => {
       await tick();
     }
 
-    // Set time to more than 1 minute after start to trigger cleanup
-    vi.setSystemTime(startTime + 75000); // 75 seconds after start
-    
-    // Advance timers to trigger cleanup interval
-    vi.advanceTimersByTime(6000); // Trigger cleanup (runs every 5 seconds)
+    vi.setSystemTime(startTime + 75000);
+    vi.advanceTimersByTime(6000);
     await tick();
 
-    // Check that old data has been cleaned up
     const sparklineData = get(sparklineStore.data);
     const voltageData = sparklineData[0]?.voltage || [];
-    
-    // All remaining data points should be within the last minute from current time
-    const currentTime = Date.now();
-    const oneMinuteAgo = currentTime - 60000;
-    
-    voltageData.forEach(point => {
+    const oneMinuteAgo = Date.now() - 60000;
+
+    voltageData.forEach((point) => {
       expect(point.timestamp).toBeGreaterThanOrEqual(oneMinuteAgo);
     });
-    
-    // Should have fewer than 10 points due to cleanup
     expect(voltageData.length).toBeLessThan(10);
   });
 
-  it('should handle offline channels gracefully', async () => {
-    const { container } = render(Sparkline, {
+  it('does not add data for offline channels', async () => {
+    render(Sparkline, {
       props: {
         channel: 0,
         metric: 'voltage',
         width: 200,
-        height: 60
-      }
+        height: 60,
+        sparklineStore,
+      },
     });
 
-    // Set channel as offline
-    channelStore.channels.update(channels => {
+    channelStore.channels.update((channels) => {
       channels[0] = {
         ...channels[0],
         online: false,
         voltage: 3.3,
         current: 0.5,
         temperature: 25.0,
-        machineType: 'Unknown'
+        machineType: 'Unknown',
       };
       return channels;
     });
@@ -313,17 +263,12 @@ describe('Sparkline Integration with Channel Store', () => {
     vi.advanceTimersByTime(100);
     await tick();
 
-    // Should not add data for offline channels
     const sparklineData = get(sparklineStore.data);
     expect(sparklineData[0]).toBeUndefined();
-    
-    // Should still show no data message  
-    // Note: Skipping no-data div check due to Svelte conditional rendering issues in test environment
   });
 
-  it('should handle target value changes in channel store', async () => {
-    // Test that channel store properly sets target values
-    channelStore.channels.update(channels => {
+  it('handles target value changes in channel store', async () => {
+    channelStore.channels.update((channels) => {
       channels[0] = {
         ...channels[0],
         online: true,
@@ -331,9 +276,9 @@ describe('Sparkline Integration with Channel Store', () => {
         current: 0.5,
         targetVoltage: 3.3,
         targetCurrent: 0.6,
-        targetPower: 1.98, // 3.3 * 0.6
+        targetPower: 1.98,
         temperature: 25.0,
-        machineType: 'P906'
+        machineType: 'P906',
       };
       return channels;
     });
@@ -342,17 +287,14 @@ describe('Sparkline Integration with Channel Store', () => {
     vi.advanceTimersByTime(100);
     await tick();
 
-    // Verify channel data has target values set
     const channels = get(channelStore.channels);
     expect(channels[0].targetVoltage).toBe(3.3);
     expect(channels[0].targetCurrent).toBe(0.6);
     expect(channels[0].targetPower).toBe(1.98);
-    
-    // Verify sparkline data was populated
+
     const sparklineData = get(sparklineStore.data);
-    expect(sparklineData[0]).toBeDefined();
-    expect(sparklineData[0].voltage).toBeDefined();
-    expect(sparklineData[0].current).toBeDefined();
-    expect(sparklineData[0].power).toBeDefined();
+    expect(sparklineData[0]?.voltage).toBeDefined();
+    expect(sparklineData[0]?.current).toBeDefined();
+    expect(sparklineData[0]?.power).toBeDefined();
   });
 });

--- a/mdp-webui/tests/mocks/components/MockChannelDetail.svelte
+++ b/mdp-webui/tests/mocks/components/MockChannelDetail.svelte
@@ -1,6 +1,5 @@
 <script>
-  import { channelStore } from '$lib/stores/channels.js';
-  
+  export let channelStore;
   export let channel = 0;
   export let onback = undefined;
   

--- a/mdp-webui/tests/mocks/components/MockDashboard.svelte
+++ b/mdp-webui/tests/mocks/components/MockDashboard.svelte
@@ -1,7 +1,7 @@
 <script>
-  import { channelStore } from '$lib/stores/channels.js';
   import ChannelCard from './MockChannelCard.svelte';
   
+  export let channelStore;
   export let onselectchannel = undefined;
   
   const { channels, activeChannel } = channelStore;

--- a/mdp-webui/tests/unit/core/signal.test.js
+++ b/mdp-webui/tests/unit/core/signal.test.js
@@ -1,0 +1,27 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createSignal } from '$lib/core/signal';
+
+describe('createSignal', () => {
+  it('notifies subscribers on emit', () => {
+    const signal = createSignal();
+    const handler = vi.fn();
+
+    signal.subscribe(handler);
+    signal.emit('hello');
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith('hello');
+  });
+
+  it('stops notifying after unsubscribe', () => {
+    const signal = createSignal();
+    const handler = vi.fn();
+
+    const unsubscribe = signal.subscribe(handler);
+    unsubscribe();
+
+    signal.emit('ignored');
+    expect(handler).not.toHaveBeenCalled();
+  });
+});
+

--- a/mdp-webui/tests/unit/services/packet-bus.test.js
+++ b/mdp-webui/tests/unit/services/packet-bus.test.js
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createPacketBus } from '$lib/services/packet-bus';
+import { PackType } from '$lib/packet-decoder.js';
+import { createMalformedPacket, createSynthesizePacket } from '../../mocks/packet-data.js';
+
+function createFakeSerial() {
+  const handlersByType = new Map();
+
+  return {
+    registerPacketHandler(packetType, handler) {
+      const handlers = handlersByType.get(packetType) ?? [];
+      handlers.push(handler);
+      handlersByType.set(packetType, handlers);
+
+      return () => {
+        const list = handlersByType.get(packetType);
+        if (!list) return;
+        const index = list.indexOf(handler);
+        if (index >= 0) list.splice(index, 1);
+        if (list.length === 0) handlersByType.delete(packetType);
+      };
+    },
+    emit(packetType, packet) {
+      const handlers = handlersByType.get(packetType) ?? [];
+      handlers.forEach((handler) => handler(packet));
+    },
+    getRegisteredTypes() {
+      return Array.from(handlersByType.keys());
+    }
+  };
+}
+
+describe('createPacketBus', () => {
+  it('registers handlers and emits decoded events while started', () => {
+    const serial = createFakeSerial();
+    const bus = createPacketBus(serial);
+
+    const onRawPacket = vi.fn();
+    const onDecodedPacket = vi.fn();
+    const onSynthesize = vi.fn();
+
+    bus.onRawPacket.subscribe(onRawPacket);
+    bus.onDecodedPacket.subscribe(onDecodedPacket);
+    bus.onSynthesize.subscribe(onSynthesize);
+
+    bus.start();
+    bus.start(); // idempotent
+
+    expect(serial.getRegisteredTypes()).toEqual(
+      expect.arrayContaining([
+        PackType.SYNTHESIZE,
+        PackType.WAVE,
+        PackType.ADDR,
+        PackType.UPDAT_CH,
+        PackType.MACHINE,
+        PackType.ERR_240,
+      ])
+    );
+
+    const synthesizePacket = Array.from(
+      createSynthesizePacket([{ online: 1, type: 1, voltage: 5000, current: 1000 }])
+    );
+    serial.emit(PackType.SYNTHESIZE, synthesizePacket);
+
+    expect(onRawPacket).toHaveBeenCalledTimes(1);
+    expect(onDecodedPacket).toHaveBeenCalledTimes(1);
+    expect(onSynthesize).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not emit events after stop', () => {
+    const serial = createFakeSerial();
+    const bus = createPacketBus(serial);
+
+    const onRawPacket = vi.fn();
+    bus.onRawPacket.subscribe(onRawPacket);
+
+    bus.start();
+    serial.emit(PackType.SYNTHESIZE, Array.from(createSynthesizePacket()));
+    expect(onRawPacket).toHaveBeenCalledTimes(1);
+
+    bus.stop();
+    serial.emit(PackType.SYNTHESIZE, Array.from(createSynthesizePacket()));
+    expect(onRawPacket).toHaveBeenCalledTimes(1);
+  });
+
+  it('emits raw packets even when decode fails', () => {
+    const serial = createFakeSerial();
+    const bus = createPacketBus(serial);
+
+    const onRawPacket = vi.fn();
+    const onDecodedPacket = vi.fn();
+
+    bus.onRawPacket.subscribe(onRawPacket);
+    bus.onDecodedPacket.subscribe(onDecodedPacket);
+
+    bus.start();
+    serial.emit(PackType.SYNTHESIZE, Array.from(createMalformedPacket('short')));
+
+    expect(onRawPacket).toHaveBeenCalledTimes(1);
+    expect(onDecodedPacket).not.toHaveBeenCalled();
+  });
+});
+

--- a/mdp-webui/tests/unit/stores/channels.test.js
+++ b/mdp-webui/tests/unit/stores/channels.test.js
@@ -1,446 +1,255 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { createSynthesizePacket, createWavePacket, createUpdateChannelPacket } from '../../mocks/packet-data.js';
-import { serialConnection as serialConnectionImport } from '$lib/serial.js';
-import { channelStore as channelStoreImport } from '$lib/stores/channels.js';
+import { get } from 'svelte/store';
+import { createSignal } from '$lib/core/signal.js';
 
-// Mock the kaitai-wrapper first (before any imports that use it)
-vi.mock('$lib/kaitai-wrapper.js', () => {
-  const PackType = {
-    SYNTHESIZE: 0x11,
-    WAVE: 0x12,
-    ADDR: 0x13,
-    UPDAT_CH: 0x14,
-    MACHINE: 0x15
-  };
+const mockProcessSynthesizePacket = vi.hoisted(() => vi.fn());
+const mockProcessAddressPacket = vi.hoisted(() => vi.fn());
+const mockProcessMachinePacket = vi.hoisted(() => vi.fn());
 
-  class KaitaiStream {
-    constructor(buffer) {
-      this.buffer = buffer.buffer instanceof ArrayBuffer ? buffer.buffer : buffer;
-      this.pos = 0;
-      this.view = new DataView(this.buffer);
-    }
-    
-    readU1() {
-      return this.view.getUint8(this.pos++);
-    }
-    
-    readU2le() {
-      if (this.pos + 2 > this.buffer.byteLength) throw new RangeError("Offset is outside the bounds of the DataView");
-      const val = this.view.getUint16(this.pos, true);
-      this.pos += 2;
-      return val;
-    }
-    
-    readU4le() {
-      if (this.pos + 4 > this.buffer.byteLength) throw new RangeError("Offset is outside the bounds of the DataView");
-      const val = this.view.getUint32(this.pos, true);
-      this.pos += 4;
-      return val;
-    }
-    
-    readBytes(n) {
-      if (this.pos + n > this.buffer.byteLength) throw new RangeError("Offset is outside the bounds of the DataView");
-      const bytes = new Uint8Array(this.buffer.slice(this.pos, this.pos + n));
-      this.pos += n;
-      return bytes;
-    }
-  }
+vi.mock('$lib/packet-decoder.js', () => ({
+  processSynthesizePacket: mockProcessSynthesizePacket,
+  processAddressPacket: mockProcessAddressPacket,
+  processMachinePacket: mockProcessMachinePacket,
+}));
 
-  class MiniwareMdpM01 {
-    constructor(stream) {
-      this.stream = stream;
-      this.packets = [];
-      this._read();
-    }
-    
-    _read() {
-      if (this.stream.buffer.byteLength < 6) return;
-      this.stream.readU1(); // header1
-      this.stream.readU1(); // header2
-      const packetType = this.stream.readU1();
-      this.size = this.stream.readU1();
-      this.channel = this.stream.readU1();
-      this.checksum = this.stream.readU1();
-      
-      const packet = {
-        packType: packetType,
-        size: this.size,
-        channel: this.channel,
-        checksum: this.checksum,
-        data: null
-      };
-      
-      // Parse data based on packet type
-      if (packetType === PackType.SYNTHESIZE) {
-        packet.data = { channels: [] };
-        // Read actual synthesize data from stream
-        for (let i = 0; i < 6; i++) {
-          const ch = {
-            num: this.stream.readU1(),
-            outVoltageRaw: this.stream.readU2le(),
-            outCurrentRaw: this.stream.readU2le(),
-            inVoltageRaw: this.stream.readU2le(),
-            inCurrentRaw: this.stream.readU2le(),
-            setVoltageRaw: this.stream.readU2le(),
-            setCurrentRaw: this.stream.readU2le(),
-            tempRaw: this.stream.readU2le(),
-            online: this.stream.readU1(),
-            type: this.stream.readU1(),
-            lock: this.stream.readU1(),
-            statusLoad: this.stream.readU1(),
-            outputOn: this.stream.readU1(),
-            color: this.stream.readBytes(3),
-            error: this.stream.readU1(),
-            end: this.stream.readBytes(1)
-          };
-          // Add computed properties
-          ch.outVoltage = ch.outVoltageRaw / 1000.0;
-          ch.outCurrent = ch.outCurrentRaw / 1000.0;
-          ch.temperature = ch.tempRaw / 10.0;
-          packet.data.channels.push(ch);
-        }
-      } else if (packetType === PackType.WAVE) {
-        packet.data = {
-          channel: this.channel,
-          groups: [{
-            timestamp: 1000,
-            items: [
-              { voltage: 3.3, current: 0.5 },
-              { voltage: 3.3, current: 0.5 }
-            ]
-          }]
-        };
-      }
-      
-      this.packets.push(packet);
-    }
-  }
-  
-  MiniwareMdpM01.PackType = PackType;
-  
+import { createChannelStore } from '$lib/stores/channels.js';
+
+function createPacketBus() {
   return {
-    KaitaiStream,
-    MiniwareMdpM01
+    start: vi.fn(),
+    stop: vi.fn(),
+    onRawPacket: createSignal(),
+    onDecodedPacket: createSignal(),
+    onSynthesize: createSignal(),
+    onWave: createSignal(),
+    onAddress: createSignal(),
+    onMachine: createSignal(),
+    onUpdateChannel: createSignal(),
   };
-});
-
-// Mock the serial connection
-vi.mock('$lib/serial.js', () => {
-  const mockHandlers = {};
-  
-  return {
-    serialConnection: {
-      registerPacketHandler: vi.fn((type, handler) => {
-        mockHandlers[type] = handler;
-      }),
-      sendPacket: vi.fn(),
-      deviceTypeStore: {
-        set: vi.fn()
-      },
-      _mockHandlers: mockHandlers
-    }
-  };
-});
+}
 
 describe('Channel Store', () => {
+  let packets;
+  let serial;
   let channelStore;
-  let serialConnection;
-  let packetHandlers = {};
-  
-  beforeEach(async () => {
+
+  beforeEach(() => {
     vi.clearAllMocks();
-    vi.resetModules();
-    packetHandlers = {};
 
-    // Re-import mocks and store to re-initialize
-    const serialModule = await import('$lib/serial.js');
-    serialConnection = serialModule.serialConnection;
+    packets = createPacketBus();
+    serial = {
+      sendPacket: vi.fn().mockResolvedValue(undefined),
+      setDeviceType: vi.fn(),
+    };
 
-    // Capture packet handlers
-    serialConnection.registerPacketHandler.mockImplementation((type, handler) => {
-      packetHandlers[type] = handler;
-    });
-    
-    const storeModule = await import('$lib/stores/channels.js');
-    channelStore = storeModule.channelStore;
+    channelStore = createChannelStore({ serial, packets });
   });
 
   describe('Initial State', () => {
-    it('should initialize with 6 offline channels', () => {
-      let channels;
-      const unsubscribe = channelStore.channels.subscribe(value => channels = value);
-      
+    it('initializes with 6 offline channels', () => {
+      const channels = get(channelStore.channels);
       expect(channels).toHaveLength(6);
-      channels.forEach((channel, index) => {
-        expect(channel.channel).toBe(index);
-        expect(channel.online).toBe(false);
-        expect(channel.voltage).toBe(0);
-        expect(channel.current).toBe(0);
+      channels.forEach((ch, i) => {
+        expect(ch.channel).toBe(i);
+        expect(ch.online).toBe(false);
+        expect(ch.waveformData).toEqual([]);
+        expect(ch.recording).toBe(false);
       });
-      
-      unsubscribe();
     });
 
-    it('should initialize with channel 0 as active', () => {
-      let activeChannel;
-      const unsubscribe = channelStore.activeChannel.subscribe(value => activeChannel = value);
-      
-      expect(activeChannel).toBe(0);
-      
-      unsubscribe();
+    it('starts with waitingSynthesize true', () => {
+      expect(get(channelStore.waitingSynthesize)).toBe(true);
     });
   });
 
-  describe('Packet Handler Registration', () => {
-    it('should register handlers for all expected packet types', () => {
-      expect(serialConnection.registerPacketHandler).toHaveBeenCalledWith(0x11, expect.any(Function));
-      expect(serialConnection.registerPacketHandler).toHaveBeenCalledWith(0x12, expect.any(Function));
-      expect(serialConnection.registerPacketHandler).toHaveBeenCalledWith(0x14, expect.any(Function));
-      expect(serialConnection.registerPacketHandler).toHaveBeenCalledWith(0x15, expect.any(Function));
-    });
-  });
+  describe('Packet Handling', () => {
+    it('updates channel data on synthesize packets', () => {
+      mockProcessSynthesizePacket.mockReturnValue(
+        Array.from({ length: 6 }, (_, i) => ({
+          channel: i,
+          online: i === 2,
+          machineType: 'P906',
+          voltage: i === 2 ? 5 : 0,
+          current: i === 2 ? 1 : 0,
+          power: i === 2 ? 5 : 0,
+          temperature: 25,
+          isOutput: false,
+          mode: 'Normal',
+          inputVoltage: 0,
+          inputCurrent: 0,
+          inputPower: 0,
+          targetVoltage: 0,
+          targetCurrent: 0,
+          targetPower: 0,
+        }))
+      );
 
-  describe('Synthesize Packet Handling', () => {
-    it('should update channels with synthesize packet data', () => {
-      const synthesizeHandler = packetHandlers[0x11];
-      expect(synthesizeHandler).toBeDefined();
-      
-      const packet = createSynthesizePacket();
-      synthesizeHandler(packet);
-      
-      let channels;
-      const unsubscribe = channelStore.channels.subscribe(value => channels = value);
-      
-      // First channel should be online
-      expect(channels[0].online).toBe(true);
-      expect(channels[0].voltage).toBeCloseTo(3.3);
-      expect(channels[0].current).toBeCloseTo(0.5);
-      expect(channels[0].temperature).toBeCloseTo(25.5);
-      
-      // Other channels should be offline
-      for (let i = 1; i < 6; i++) {
-        expect(channels[i].online).toBe(false);
-      }
-      
-      unsubscribe();
+      packets.onSynthesize.emit({ packType: 0x11, size: 0, data: { channels: [] } });
+
+      const channels = get(channelStore.channels);
+      expect(channels[2].online).toBe(true);
+      expect(channels[2].voltage).toBe(5);
+      expect(channels[2].current).toBe(1);
+      expect(get(channelStore.waitingSynthesize)).toBe(false);
     });
 
-    it('should preserve waveform data when updating channels', () => {
-      // First add some waveform data
-      channelStore.channels.update(chs => {
-        chs[0].waveformData = [{ timestamp: 1000, voltage: 3.3, current: 0.5 }];
-        return chs;
-      });
-      
-      const synthesizeHandler = packetHandlers[0x11];
-      const packet = createSynthesizePacket();
-      synthesizeHandler(packet);
-      
-      let channels;
-      const unsubscribe = channelStore.channels.subscribe(value => channels = value);
-      
-      // Waveform data should be preserved
-      expect(channels[0].waveformData).toHaveLength(1);
-      expect(channels[0].waveformData[0].timestamp).toBe(1000);
-      
-      unsubscribe();
-    });
-  });
+    it('updates activeChannel from update-channel packets', () => {
+      expect(get(channelStore.activeChannel)).toBe(0);
 
-  describe('Wave Packet Handling', () => {
-    it('should add wave data to recording channel', () => {
-      // Start recording on channel 0
-      channelStore.channels.update(chs => {
-        chs[0].recording = true;
-        return chs;
-      });
-      
-      const waveHandler = packetHandlers[0x12];
-      expect(waveHandler).toBeDefined();
-      
-      const packet = createWavePacket(0, 126);
-      waveHandler(packet);
-      
-      let channels;
-      const unsubscribe = channelStore.channels.subscribe(value => channels = value);
-      
-      // Should have added wave data
-      expect(channels[0].waveformData.length).toBeGreaterThan(0);
-      
-      unsubscribe();
+      packets.onUpdateChannel.emit({ data: { targetChannel: 3 } });
+
+      expect(get(channelStore.activeChannel)).toBe(3);
     });
 
-    it('should not add wave data to non-recording channel', () => {
-      const waveHandler = packetHandlers[0x12];
-      const packet = createWavePacket(0, 126);
-      waveHandler(packet);
-      
-      let channels;
-      const unsubscribe = channelStore.channels.subscribe(value => channels = value);
-      
-      // Should not have added wave data
-      expect(channels[0].waveformData).toHaveLength(0);
-      
-      unsubscribe();
-    });
-  });
+    it('updates address from address packets', () => {
+      mockProcessAddressPacket.mockReturnValue([
+        { channel: 1, address: [1, 2, 3, 4, 5], frequency: 2450 },
+      ]);
 
-  describe('Update Channel Packet Handling', () => {
-    it('should update active channel', () => {
-      const updateHandler = packetHandlers[0x14];
-      expect(updateHandler).toBeDefined();
-      
-      const packet = createUpdateChannelPacket(3);
-      updateHandler(packet);
-      
-      let activeChannel;
-      const unsubscribe = channelStore.activeChannel.subscribe(value => activeChannel = value);
-      
-      expect(activeChannel).toBe(3);
-      
-      unsubscribe();
+      packets.onAddress.emit({ packType: 0x13, size: 0, data: { addresses: [] } });
+
+      const channels = get(channelStore.channels);
+      expect(channels[1].address).toEqual([1, 2, 3, 4, 5]);
+    });
+
+    it('sets device type from machine packets', () => {
+      mockProcessMachinePacket.mockReturnValue({ type: 'M01', hasLCD: true });
+      packets.onMachine.emit({ packType: 0x15, size: 0, data: { machineTypeRaw: 0x10 } });
+      expect(serial.setDeviceType).toHaveBeenCalledWith({ type: 'M01', hasLCD: true });
     });
   });
 
   describe('Channel Control Functions', () => {
-    it('should send set channel packet', async () => {
+    it('setActiveChannel sends packet and updates store', async () => {
       await channelStore.setActiveChannel(2);
-      
-      expect(serialConnection.sendPacket).toHaveBeenCalled();
-      const sentPacket = serialConnection.sendPacket.mock.calls[0][0];
-      expect(sentPacket[2]).toBe(0x19); // PACK_SET_CH
-      
-      let activeChannel;
-      const unsubscribe = channelStore.activeChannel.subscribe(value => activeChannel = value);
-      expect(activeChannel).toBe(2);
-      unsubscribe();
+      expect(serial.sendPacket).toHaveBeenCalled();
+      expect(get(channelStore.activeChannel)).toBe(2);
     });
 
-    it('should send set voltage packet and update target values', async () => {
+    it('setVoltage sends packet and updates target values', async () => {
       await channelStore.setVoltage(1, 5.0, 1.0);
-      
-      expect(serialConnection.sendPacket).toHaveBeenCalled();
-      const sentPacket = serialConnection.sendPacket.mock.calls[0][0];
-      expect(sentPacket[2]).toBe(0x1A); // PACK_SET_V
-      
-      let channels;
-      const unsubscribe = channelStore.channels.subscribe(value => channels = value);
+
+      expect(serial.sendPacket).toHaveBeenCalled();
+      const channels = get(channelStore.channels);
       expect(channels[1].targetVoltage).toBe(5.0);
       expect(channels[1].targetCurrent).toBe(1.0);
-      unsubscribe();
+      expect(channels[1].targetPower).toBe(5.0);
     });
 
-    it('should send set current packet', async () => {
+    it('setCurrent sends packet and updates target values', async () => {
       await channelStore.setCurrent(2, 3.3, 2.0);
-      
-      expect(serialConnection.sendPacket).toHaveBeenCalled();
-      const sentPacket = serialConnection.sendPacket.mock.calls[0][0];
-      expect(sentPacket[2]).toBe(0x1B); // PACK_SET_I
+
+      expect(serial.sendPacket).toHaveBeenCalled();
+      const channels = get(channelStore.channels);
+      expect(channels[2].targetVoltage).toBe(3.3);
+      expect(channels[2].targetCurrent).toBe(2.0);
+      expect(channels[2].targetPower).toBeCloseTo(6.6);
     });
 
-    it('should send set output packet', async () => {
+    it('setOutput sends packet', async () => {
       await channelStore.setOutput(3, true);
-      
-      expect(serialConnection.sendPacket).toHaveBeenCalled();
-      const sentPacket = serialConnection.sendPacket.mock.calls[0][0];
-      expect(sentPacket[2]).toBe(0x16); // PACK_SET_ISOUTPUT
+      expect(serial.sendPacket).toHaveBeenCalled();
     });
   });
 
   describe('Recording Functions', () => {
-    it('should start recording for a channel', () => {
+    it('startRecording initializes waveform capture for a channel', () => {
       channelStore.startRecording(1);
-      
-      let channels;
-      const unsubscribe = channelStore.channels.subscribe(value => channels = value);
-      
+      const channels = get(channelStore.channels);
       expect(channels[1].recording).toBe(true);
       expect(channels[1].waveformData).toHaveLength(0);
-      
-      unsubscribe();
+      expect(channels[1].runningTimeUs).toBe(0);
     });
 
-    it('should stop recording for a channel', () => {
-      // First start recording
+    it('wave packets append waveform points while recording', () => {
       channelStore.startRecording(2);
-      
-      // Add some wave data
-      const waveHandler = packetHandlers[0x12];
-      const packet = createWavePacket(2, 126);
-      waveHandler(packet);
-      
-      // Stop recording
-      channelStore.stopRecording(2);
-      
-      let channels;
-      const unsubscribe = channelStore.channels.subscribe(value => channels = value);
-      
-      expect(channels[2].recording).toBe(false);
-      expect(channels[2].waveformData.length).toBeGreaterThan(0); // Data preserved
-      
-      unsubscribe();
+
+      packets.onWave.emit({
+        packType: 0x12,
+        size: 126,
+        data: {
+          channel: 2,
+          groups: [
+            {
+              timestamp: 1000,
+              items: [
+                { voltage: 3.3, current: 0.5 },
+                { voltage: 3.31, current: 0.51 },
+              ],
+            },
+          ],
+        },
+      });
+
+      const ch = get(channelStore.channels)[2];
+      expect(ch.waveformData.length).toBeGreaterThan(0);
     });
 
-    it('should clear recording data', () => {
-      // Start recording and add some data via wave packet
+    it('stopRecording preserves collected waveform data', () => {
       channelStore.startRecording(3);
-      const waveHandler = packetHandlers[0x12];
-      const packet = createWavePacket(3, 126);
-      waveHandler(packet);
-      
-      // Clear recording
-      channelStore.clearRecording(3);
-      
-      let channels;
-      const unsubscribe = channelStore.channels.subscribe(value => channels = value);
-      
-      // Channel 3 should have empty waveform data after clearing
-      expect(channels[3].waveformData).toHaveLength(0);
-      
-      unsubscribe();
+
+      packets.onWave.emit({
+        packType: 0x12,
+        size: 126,
+        data: {
+          channel: 3,
+          groups: [
+            {
+              timestamp: 1000,
+              items: [
+                { voltage: 3.3, current: 0.5 },
+                { voltage: 3.3, current: 0.5 },
+              ],
+            },
+          ],
+        },
+      });
+
+      channelStore.stopRecording(3);
+
+      const ch = get(channelStore.channels)[3];
+      expect(ch.recording).toBe(false);
+      expect(ch.waveformData.length).toBeGreaterThan(0);
+    });
+
+    it('clearRecording removes waveform data', () => {
+      channelStore.startRecording(4);
+      packets.onWave.emit({
+        packType: 0x12,
+        size: 126,
+        data: {
+          channel: 4,
+          groups: [
+            {
+              timestamp: 1000,
+              items: [
+                { voltage: 3.3, current: 0.5 },
+                { voltage: 3.3, current: 0.5 },
+              ],
+            },
+          ],
+        },
+      });
+
+      channelStore.clearRecording(4);
+      const ch = get(channelStore.channels)[4];
+      expect(ch.waveformData).toHaveLength(0);
     });
   });
 
   describe('Derived Stores', () => {
-    it('should provide recording channels', () => {
-      // Start recording on channels 1 and 3
+    it('recordingChannels returns channels with recording=true', () => {
       channelStore.startRecording(1);
       channelStore.startRecording(3);
-      
-      let recordingChannels;
-      const unsubscribe = channelStore.recordingChannels.subscribe(value => recordingChannels = value);
-      
-      expect(recordingChannels).toHaveLength(2);
-      expect(recordingChannels[0].channel).toBe(1);
-      expect(recordingChannels[1].channel).toBe(3);
-      
-      unsubscribe();
+
+      const recordingChannels = get(channelStore.recordingChannels);
+      expect(recordingChannels.map((c) => c.channel)).toEqual([1, 3]);
     });
 
-    it('should provide active channel data', async () => {
-      // Make channel 2 active
+    it('activeChannelData reflects current active channel', async () => {
       await channelStore.setActiveChannel(2);
-      
-      // Send synthesize packet with data for channel 2
-      const synthesizeHandler = packetHandlers[0x11];
-      const packet = createSynthesizePacket([
-        { online: 0 },
-        { online: 0 },
-        { online: 1, voltage: 5000, current: 1000 },
-        { online: 0 },
-        { online: 0 },
-        { online: 0 }
-      ]);
-      synthesizeHandler(packet);
-      
-      let activeChannelData;
-      const unsubscribe = channelStore.activeChannelData.subscribe(value => activeChannelData = value);
-      
-      expect(activeChannelData.channel).toBe(2);
-      expect(activeChannelData.online).toBe(true);
-      expect(activeChannelData.voltage).toBe(5.0);
-      
-      unsubscribe();
+      const active = get(channelStore.activeChannelData);
+      expect(active.channel).toBe(2);
     });
   });
 });

--- a/mdp-webui/tests/unit/stores/timeseries-integration.test.js
+++ b/mdp-webui/tests/unit/stores/timeseries-integration.test.js
@@ -1,346 +1,273 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { get } from 'svelte/store';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { get, writable } from 'svelte/store';
+import { createSignal } from '$lib/core/signal.js';
+import { createTimeseriesStore } from '$lib/stores/timeseries.js';
+import { createTimeseriesIntegration } from '$lib/stores/timeseries-integration.js';
 
-// Mock kaitai-wrapper before importing anything that uses it
-vi.mock('$lib/kaitai-wrapper.js', () => ({
-  KaitaiStream: vi.fn(),
-  MiniwareMdpM01: {
-    PackType: {
-      PACK_HEARTBEAT: 0x22,
-      PACK_SET_CH: 0x19,
-      PACK_SET_V: 0x1A,
-      PACK_SET_I: 0x1B,
-      PACK_SET_ADDR: 0x18,
-      PACK_SET_ALL_ADDR: 0x1C,
-      PACK_SET_ISOUTPUT: 0x16,
-      PACK_SYNTHESIZE: 0x11,
-      PACK_WAVE: 0x12,
-      PACK_ADDR: 0x13,
-      PACK_UPDAT_CH: 0x14,
-      PACK_MACHINE: 0x15,
-      PACK_ERR_240: 0x23
-    }
-  }
-}));
+function createPacketBus() {
+  return {
+    start: () => {},
+    stop: () => {},
+    onRawPacket: createSignal(),
+    onDecodedPacket: createSignal(),
+    onSynthesize: createSignal(),
+    onWave: createSignal(),
+    onAddress: createSignal(),
+    onMachine: createSignal(),
+    onUpdateChannel: createSignal(),
+  };
+}
 
-// Create mock functions that will be reused
-const mockDecodeSynthesize = vi.fn();
-const mockDecodeWave = vi.fn();
-
-// Mock the serial connection
-vi.mock('$lib/serial.js', () => ({
-  serialConnection: {
-    registerPacketHandler: vi.fn(),
-    getDecoder: vi.fn(() => ({
-      decodeSynthesize: mockDecodeSynthesize,
-      decodeWave: mockDecodeWave
+function createChannelStoreStub() {
+  const channels = writable(
+    Array.from({ length: 6 }, (_, i) => ({
+      channel: i,
+      online: false,
+      machineType: 'Unknown',
+      voltage: 0,
+      current: 0,
+      power: 0,
+      temperature: 0,
+      isOutput: false,
+      mode: 'Normal',
+      address: [0, 0, 0, 0, 0],
+      targetVoltage: 0,
+      targetCurrent: 0,
+      targetPower: 0,
+      recording: false,
+      waveformData: [],
     }))
-  }
-}));
+  );
 
-import { timeseriesStore } from '$lib/stores/timeseries.js';
-import { channelStore } from '$lib/stores/channels.js';
-import { serialConnection } from '$lib/serial.js';
+  return {
+    channels,
+    startRecording: (channel) => {
+      channels.update((chs) => {
+        const next = [...chs];
+        next[channel] = { ...next[channel], recording: true, waveformData: [] };
+        return next;
+      });
+    },
+    stopRecording: (channel) => {
+      channels.update((chs) => {
+        const next = [...chs];
+        next[channel] = { ...next[channel], recording: false };
+        return next;
+      });
+    },
+  };
+}
 
 describe('TimeseriesIntegration', () => {
-  let mockHandlers;
+  let packets;
+  let timeseries;
+  let channels;
   let integration;
 
-  beforeEach(async () => {
-    // Reset stores
-    timeseriesStore.reset();
-    channelStore.reset();
-
-    // Reset mocks
-    mockDecodeSynthesize.mockClear();
-    mockDecodeWave.mockClear();
-    serialConnection.registerPacketHandler.mockClear();
-
-    mockHandlers = new Map();
-    serialConnection.registerPacketHandler.mockImplementation((type, handler) => {
-      if (!mockHandlers.has(type)) {
-        mockHandlers.set(type, []);
-      }
-      mockHandlers.get(type).push(handler);
-    });
-
-    // Don't use vi.resetModules() as it causes multiple imports
-    // Instead, just import fresh each time - the mock should capture properly
-    integration = await import('$lib/stores/timeseries-integration.js');
-    integration.initializeTimeseriesIntegration();
+  beforeEach(() => {
+    packets = createPacketBus();
+    timeseries = createTimeseriesStore();
+    channels = createChannelStoreStub();
+    integration = createTimeseriesIntegration({ packets, timeseries, channels });
   });
 
-  afterEach(() => {
-    timeseriesStore.stopAutoCleanup();
-  });
+  describe('Packet Bus Integration', () => {
+    it('processes synthesize packets when session is active', () => {
+      integration.startRecording([0, 1, 2]);
 
-  describe('Packet Handler Integration', () => {
-    it('should register handlers for synthesize and wave packets', () => {
-      expect(serialConnection.registerPacketHandler).toHaveBeenCalledWith(0x11, expect.any(Function));
-      expect(serialConnection.registerPacketHandler).toHaveBeenCalledWith(0x12, expect.any(Function));
-      expect(mockHandlers.has(0x11)).toBe(true);
-      expect(mockHandlers.has(0x12)).toBe(true);
-      expect(mockHandlers.get(0x11)).toHaveLength(1);
-      expect(mockHandlers.get(0x12)).toHaveLength(1);
-    });
-
-    it('should process synthesize packets when session is active', () => {
-      // Create recording session
-      const sessionId = integration.startRecording([0, 1, 2]);
-      
-      // Verify session was created
-      expect(sessionId).toBeTruthy();
-      const activeSession = get(timeseriesStore.activeSession);
-      expect(activeSession).toBeTruthy();
-      
-      // Mock synthesize packet data
-      mockDecodeSynthesize.mockReturnValue({
+      packets.onSynthesize.emit({
+        packType: 0x11,
+        size: 0,
         data: {
           channels: [
-            { outVoltage: 3.3, outCurrent: 0.5, temperature: 25.5, outputOn: 1 },
-            { outVoltage: 5.0, outCurrent: 1.0, temperature: 26.0, outputOn: 1 },
-            { outVoltage: 12.0, outCurrent: 0.25, temperature: 24.0, outputOn: 0 }
-          ]
-        }
+            { outVoltage: 3.3, outCurrent: 0.5, temperature: 25.5, outputOn: 1, type: 2, statusPsu: 2, statusLoad: 0 },
+            { outVoltage: 5.0, outCurrent: 1.0, temperature: 26.0, outputOn: 1, type: 2, statusPsu: 1, statusLoad: 0 },
+            { outVoltage: 12.0, outCurrent: 0.25, temperature: 24.0, outputOn: 0, type: 3, statusLoad: 0, statusPsu: 0 },
+          ],
+        },
       });
-      
-      // Simulate synthesize packet - use the last registered handler
-      const handlers = mockHandlers.get(0x11);
-      expect(handlers).toBeTruthy();
-      expect(handlers.length).toBeGreaterThan(0);
-      const synthHandler = handlers[handlers.length - 1]; // Use latest handler
-      
-      synthHandler([0x5A, 0x5A, 0x11, 156, 0, 0]); // Mock packet header
-      
-      // Verify data was stored
-      const sessionData = get(timeseriesStore.activeSessionData);
+
+      const sessionData = get(timeseries.activeSessionData);
       expect(sessionData).toHaveLength(1);
       expect(sessionData[0]).toMatchObject({
         ch0: { voltage: 3.3, current: 0.5, temperature: 25.5, isOutput: true },
         ch1: { voltage: 5.0, current: 1.0, temperature: 26.0, isOutput: true },
-        ch2: { voltage: 12.0, current: 0.25, temperature: 24.0, isOutput: false }
+        ch2: { voltage: 12.0, current: 0.25, temperature: 24.0, isOutput: false },
       });
     });
 
-    it('should process wave packets for active channels', () => {
-      // Create recording session for channel 0
-      const sessionId = integration.startRecording([0]);
-      
-      // Mock wave packet data
-      mockDecodeWave.mockReturnValue({
+    it('processes wave packets for active channels', () => {
+      integration.startRecording([0]);
+
+      packets.onWave.emit({
+        packType: 0x12,
+        size: 0,
         data: {
+          channel: 0,
           groups: [
             {
               timestamp: 1000,
               items: [
                 { voltage: 3.3, current: 0.5 },
-                { voltage: 3.31, current: 0.51 }
-              ]
+                { voltage: 3.31, current: 0.51 },
+              ],
             },
             {
               timestamp: 1020,
               items: [
                 { voltage: 3.32, current: 0.52 },
-                { voltage: 3.33, current: 0.53 }
-              ]
-            }
-          ]
-        }
+                { voltage: 3.33, current: 0.53 },
+              ],
+            },
+          ],
+        },
       });
-      
-      // Simulate wave packet for channel 0
-      const waveHandlers = mockHandlers.get(0x12);
-      expect(waveHandlers).toBeTruthy();
-      const waveHandler = waveHandlers[waveHandlers.length - 1];
-      waveHandler([0x5A, 0x5A, 0x12, 126, 0, 0]); // Channel 0 in header
-      
-      // Verify data was stored with correct timestamps
-      const sessionData = get(timeseriesStore.activeSessionData);
+
+      const sessionData = get(timeseries.activeSessionData);
       expect(sessionData).toHaveLength(4);
-      expect(sessionData[0]).toMatchObject({
-        timestamp: 1000,
-        ch0: { voltage: 3.3, current: 0.5 }
-      });
-      expect(sessionData[1]).toMatchObject({
-        timestamp: 1010,
-        ch0: { voltage: 3.31, current: 0.51 }
-      });
-      expect(sessionData[2]).toMatchObject({
-        timestamp: 1020,
-        ch0: { voltage: 3.32, current: 0.52 }
-      });
-      expect(sessionData[3]).toMatchObject({
-        timestamp: 1030,
-        ch0: { voltage: 3.33, current: 0.53 }
-      });
+      expect(sessionData[0]).toMatchObject({ timestamp: 1000, ch0: { voltage: 3.3, current: 0.5 } });
+      expect(sessionData[1]).toMatchObject({ timestamp: 1010, ch0: { voltage: 3.31, current: 0.51 } });
+      expect(sessionData[2]).toMatchObject({ timestamp: 1020, ch0: { voltage: 3.32, current: 0.52 } });
+      expect(sessionData[3]).toMatchObject({ timestamp: 1030, ch0: { voltage: 3.33, current: 0.53 } });
     });
 
-    it('should ignore packets when no active session', () => {
-      mockDecodeSynthesize.mockReturnValue({
-        data: { channels: [{ outVoltage: 3.3, outCurrent: 0.5 }] }
+    it('ignores packets when no active session', () => {
+      packets.onSynthesize.emit({
+        packType: 0x11,
+        size: 0,
+        data: { channels: [{ outVoltage: 3.3, outCurrent: 0.5, temperature: 25.5, outputOn: 1, type: 2, statusPsu: 2, statusLoad: 0 }] },
       });
-      
-      // No session created - packets should be ignored
-      const synthHandlers = mockHandlers.get(0x11);
-      expect(synthHandlers).toBeTruthy();
-      const synthHandler = synthHandlers[synthHandlers.length - 1];
-      synthHandler([0x5A, 0x5A, 0x11, 156, 0, 0]);
-      
-      const sessions = get(timeseriesStore.sessionList);
+
+      const sessions = get(timeseries.sessionList);
       expect(sessions).toHaveLength(0);
     });
   });
 
   describe('Recording Control', () => {
-    it('should start recording with specified channels', () => {
+    it('starts recording with specified channels', () => {
       const sessionId = integration.startRecording([0, 2, 4]);
-      
+
       expect(sessionId).toBeTruthy();
-      const activeSession = get(timeseriesStore.activeSession);
-      expect(activeSession).toBeTruthy();
+      const activeSession = get(timeseries.activeSession);
       expect(activeSession.channels).toEqual(new Set([0, 2, 4]));
-      
-      // Check channel store recording state
-      const channels = get(channelStore.channels);
-      expect(channels[0].recording).toBe(true);
-      expect(channels[1].recording).toBe(false);
-      expect(channels[2].recording).toBe(true);
-      expect(channels[3].recording).toBe(false);
-      expect(channels[4].recording).toBe(true);
+
+      const channelData = get(channels.channels);
+      expect(channelData[0].recording).toBe(true);
+      expect(channelData[1].recording).toBe(false);
+      expect(channelData[2].recording).toBe(true);
+      expect(channelData[4].recording).toBe(true);
     });
 
-    it('should stop recording and close session', () => {
-      const sessionId = integration.startRecording([0, 1]);
+    it('stops recording and closes session', () => {
+      integration.startRecording([0, 1]);
       integration.stopRecording();
-      
-      // Check session is closed
-      const activeSession = get(timeseriesStore.activeSession);
-      expect(activeSession).toBeNull();
-      
-      // Check channels are not recording
-      const channels = get(channelStore.channels);
-      channels.forEach(ch => {
-        expect(ch.recording).toBe(false);
-      });
-      
-      // Session should still exist but be closed
-      const sessions = get(timeseriesStore.sessionList);
+
+      expect(get(timeseries.activeSession)).toBeNull();
+
+      const channelData = get(channels.channels);
+      channelData.forEach((ch) => expect(ch.recording).toBe(false));
+
+      const sessions = get(timeseries.sessionList);
       expect(sessions[0].endTime).toBeTruthy();
     });
   });
 
   describe('Data Export', () => {
-    it('should export session data to CSV', () => {
-      // Create session and add data
-      const sessionId = integration.startRecording([0, 1]);
+    it('exports active session data to CSV', () => {
+      integration.startRecording([0, 1]);
       const baseTime = Date.now();
-      
-      timeseriesStore.addDataPoints([
+
+      timeseries.addDataPoints([
         { channel: 0, timestamp: baseTime, data: { voltage: 3.3, current: 0.5 } },
         { channel: 1, timestamp: baseTime, data: { voltage: 5.0, current: 1.0 } },
         { channel: 0, timestamp: baseTime + 100, data: { voltage: 3.31, current: 0.51 } },
-        { channel: 1, timestamp: baseTime + 100, data: { voltage: 5.01, current: 1.01 } }
+        { channel: 1, timestamp: baseTime + 100, data: { voltage: 5.01, current: 1.01 } },
       ]);
-      
+
       const csv = integration.exportSessionToCSV();
       const lines = csv.split('\n');
-      
-      expect(lines[0]).toBe('Timestamp (ms),Time (s),Ch0 Voltage (V),Ch0 Current (A),Ch0 Power (W),Ch1 Voltage (V),Ch1 Current (A),Ch1 Power (W)');
-      expect(lines[1]).toContain('0.000'); // First timestamp at 0s
-      expect(lines[2]).toContain('0.100'); // Second timestamp at 0.1s
+
+      expect(lines[0]).toBe(
+        'Timestamp (ms),Time (s),Ch0 Voltage (V),Ch0 Current (A),Ch0 Power (W),Ch1 Voltage (V),Ch1 Current (A),Ch1 Power (W)'
+      );
+      expect(lines[1]).toContain('0.000');
+      expect(lines[2]).toContain('0.100');
       expect(lines[1]).toContain('3.300,0.500,1.650,5.000,1.000,5.000');
     });
 
-    it('should export specific channels only', () => {
+    it('exports specific channels only', () => {
       const sessionId = integration.startRecording([0, 1, 2]);
       const baseTime = Date.now();
-      
-      timeseriesStore.addDataPoint(0, baseTime, { voltage: 3.3, current: 0.5 });
-      timeseriesStore.addDataPoint(1, baseTime, { voltage: 5.0, current: 1.0 });
-      timeseriesStore.addDataPoint(2, baseTime, { voltage: 12.0, current: 0.25 });
-      
+
+      timeseries.addDataPoint(0, baseTime, { voltage: 3.3, current: 0.5 });
+      timeseries.addDataPoint(1, baseTime, { voltage: 5.0, current: 1.0 });
+      timeseries.addDataPoint(2, baseTime, { voltage: 12.0, current: 0.25 });
+
       const csv = integration.exportSessionToCSV(sessionId, [0, 2]);
       const lines = csv.split('\n');
-      
-      expect(lines[0]).toBe('Timestamp (ms),Time (s),Ch0 Voltage (V),Ch0 Current (A),Ch0 Power (W),Ch2 Voltage (V),Ch2 Current (A),Ch2 Power (W)');
-      expect(lines[1]).not.toContain('5.000'); // Channel 1 data excluded
+
+      expect(lines[0]).toBe(
+        'Timestamp (ms),Time (s),Ch0 Voltage (V),Ch0 Current (A),Ch0 Power (W),Ch2 Voltage (V),Ch2 Current (A),Ch2 Power (W)'
+      );
+      expect(lines[1]).not.toContain('5.000');
     });
   });
 
   describe('Chart Data Retrieval', () => {
-    it('should get chart data for active session', () => {
-      const sessionId = integration.startRecording([0]);
+    it('gets chart data for active session', () => {
+      integration.startRecording([0]);
       const now = Date.now();
-      const baseTime = now - 1000; // Start 1 second ago to ensure it's within range
-      
-      // Add data points with explicit unique timestamps within the last second
+      const baseTime = now - 1000;
+
       for (let i = 0; i < 10; i++) {
-        timeseriesStore.addDataPoint(0, baseTime + i * 50, {
-          voltage: 3.3 + i * 0.1,
-          current: 0.5 + i * 0.01
-        });
+        timeseries.addDataPoint(0, baseTime + i * 50, { voltage: 3.3 + i * 0.1, current: 0.5 + i * 0.01 });
       }
-      
-      // Get chart data for last 2 seconds, which should include all our data
+
       const chartData = integration.getChartData(0, 2000);
-      
       expect(chartData.timestamps).toHaveLength(10);
-      expect(chartData.voltage).toHaveLength(10);
-      expect(chartData.current).toHaveLength(10);
-      expect(chartData.power).toHaveLength(10);
-      
       expect(chartData.voltage[0]).toBe(3.3);
       expect(chartData.voltage[9]).toBe(4.2);
       expect(chartData.power[0]).toBeCloseTo(1.65, 2);
     });
 
-    it('should return empty data for inactive channel', () => {
+    it('returns empty data for inactive channel', () => {
       integration.startRecording([0]);
-      const chartData = integration.getChartData(1); // Channel 1 not recording
-      
+      const chartData = integration.getChartData(1);
+
       expect(chartData.timestamps).toHaveLength(0);
       expect(chartData.voltage).toHaveLength(0);
     });
   });
 
   describe('Session Statistics', () => {
-    it('should calculate session statistics', () => {
-      const sessionId = integration.startRecording([0, 1]);
+    it('calculates session statistics', () => {
+      integration.startRecording([0, 1]);
       const baseTime = Date.now();
-      
-      // Add varied data
+
       for (let i = 0; i < 10; i++) {
-        timeseriesStore.addDataPoint(0, baseTime + i * 100, {
-          voltage: 3.0 + i * 0.1, // 3.0 to 3.9
-          current: 0.5 - i * 0.01  // 0.5 to 0.41
-        });
-        timeseriesStore.addDataPoint(1, baseTime + i * 100, {
-          voltage: 5.0,
-          current: 1.0 + i * 0.02 // 1.0 to 1.18
-        });
+        timeseries.addDataPoint(0, baseTime + i * 100, { voltage: 3.0 + i * 0.1, current: 0.5 - i * 0.01 });
+        timeseries.addDataPoint(1, baseTime + i * 100, { voltage: 5.0, current: 1.0 + i * 0.02 });
       }
-      
+
       const stats = integration.getSessionStats();
-      
+
       expect(stats).toBeTruthy();
       expect(stats.channels).toEqual([0, 1]);
       expect(stats.pointCount).toBe(10);
-      
-      // Channel 0 stats
+
       expect(stats.channelStats[0].voltage.min).toBe(3.0);
       expect(stats.channelStats[0].voltage.max).toBe(3.9);
       expect(stats.channelStats[0].voltage.avg).toBeCloseTo(3.45, 2);
       expect(stats.channelStats[0].current.min).toBeCloseTo(0.41, 2);
       expect(stats.channelStats[0].current.max).toBe(0.5);
-      
-      // Channel 1 stats
+
       expect(stats.channelStats[1].voltage.min).toBe(5.0);
       expect(stats.channelStats[1].voltage.max).toBe(5.0);
       expect(stats.channelStats[1].current.min).toBe(1.0);
       expect(stats.channelStats[1].current.max).toBe(1.18);
     });
 
-    it('should handle empty session stats', () => {
+    it('handles empty session stats', () => {
       const stats = integration.getSessionStats();
       expect(stats).toBeNull();
     });


### PR DESCRIPTION
## Summary
- Introduces `AppRuntime` + Svelte context DI so the app shares a single WebSerial connection + accumulated data across views.
- Adds a typed `PacketBus` to decode packets once and fan out to domain stores.
- Refactors stores into factories (no module-side singletons) and updates components to use injected runtime/stores.
- Updates unit/integration tests for the new runtime model; adds unit coverage for `createSignal` and `createPacketBus`.

## Tests
- `cd mdp-webui && npm run lint`
- `cd mdp-webui && npm run type-check`
- `cd mdp-webui && npm run test:run`