### PR TITLE
Add wave timestamp reconciliation

### DIFF
--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -5,6 +5,7 @@ import { SerialPort } from 'serialport';
 import { get } from 'svelte/store';
 import { NodeSerialConnection } from './node-serial';
 import { ReplaySerialConnection } from './replay-serial';
+import { WaveTimestampReconciler, type WaveSample } from '../../webui/src/lib/wave-reconciler';
 import { ContextRegistry, categorizeDevice, type DeviceContext, type DeviceContextParams } from './context-registry';
 import { createPerfettoCapture, type PerfettoCapture } from '../../webui/src/lib/perfetto-capture';
 import {
@@ -43,6 +44,8 @@ const program = new Command();
 debugEnabled.set(false);
 
 const DEFAULT_WAVE_GAP_NS = 1_000_000_000;
+const DEFAULT_RECONCILE_DELAY_NS = 2_000_000_000;
+const DEFAULT_RECONCILE_TAIL_NS = 500_000_000;
 
 program.option('--debug', 'Enable Kaitai/debug logging');
 
@@ -289,43 +292,6 @@ async function waitForChannelStatus(
   return processed[channel] ?? processed[0];
 }
 
-type WaveSample = {
-  timeSeconds: number;
-  voltage: number;
-  current: number;
-};
-
-function extractWaveSamples(
-  packet: DecodedPacket,
-  runningTimeUs: number
-): { samples: WaveSample[]; nextRunningTimeUs: number } | null {
-  if (!isWavePacket(packet)) return null;
-
-  const wave = packet.data;
-  const samples: WaveSample[] = [];
-  const samplesPerGroup = packet.size === 126 ? 2 : packet.size === 206 ? 4 : 0;
-
-  wave.groups.forEach((group) => {
-    const groupElapsedTimeUs = group.timestamp / 10;
-    const pointsInGroup = samplesPerGroup || group.items.length || 1;
-    const timePerSampleUs = pointsInGroup > 0 ? groupElapsedTimeUs / pointsInGroup : 0;
-
-    for (let i = 0; i < pointsInGroup; i++) {
-      const item = group.items[i];
-      if (!item) break;
-      const sampleTimeUs = runningTimeUs + i * timePerSampleUs;
-      samples.push({
-        timeSeconds: sampleTimeUs / 1_000,
-        voltage: item.voltage,
-        current: item.current
-      });
-    }
-
-    runningTimeUs += groupElapsedTimeUs;
-  });
-
-  return { samples, nextRunningTimeUs: runningTimeUs };
-}
 
 interface ContextCommandOptions {
   channel?: string;
@@ -498,11 +464,8 @@ async function handleRecordCommand(
     ? new ReplaySerialConnection()
     : new NodeSerialConnection({ portPath: context.portPath });
   const replayClock = replayPerfettoPath ? createReplayNowNs() : null;
-  const perfettoNowNs = perfettoPath
-    ? replayClock
-      ? replayClock.nowNs
-      : createMonotonicNowNs()
-    : null;
+  const recordNowNs = replayClock ? replayClock.nowNs : createMonotonicNowNs();
+  const perfettoNowNs = perfettoPath ? recordNowNs : null;
   const perfettoCapture: PerfettoCapture | null = perfettoPath && perfettoNowNs
     ? createPerfettoCapture(perfetto, {
         processName: `mdp-cli ${alias}`,
@@ -540,52 +503,17 @@ async function handleRecordCommand(
       connection.startHeartbeat(() => createHeartbeatPacket(), 1000);
     }
 
-    let runningTimeUs = 0;
     let pointCount = 0;
     let hasWaveData = false;
     let lastWavePacketNs: number | null = null;
     const ignoredChannels = new Set<number>();
+    const reconciler = new WaveTimestampReconciler(
+      DEFAULT_RECONCILE_DELAY_NS,
+      DEFAULT_RECONCILE_TAIL_NS
+    );
 
-    const unsubscribe = connection.registerPacketHandler(PackType.WAVE, (packet) => {
-      const decoded = decodePacket(packet);
-      if (!decoded || !isWavePacket(decoded)) return;
-
-      if (decoded.data.channel !== channel) {
-        if (!ignoredChannels.has(decoded.data.channel)) {
-          ignoredChannels.add(decoded.data.channel);
-          log(`Ignoring wave data from channel ${decoded.data.channel}.`);
-        }
-        return;
-      }
-
-      if (!hasWaveData) {
-        hasWaveData = true;
-        log(`Receiving wave data for channel ${channel}...`);
-      }
-
-      if (perfettoCapture && perfettoNowNs) {
-        const packetNs = perfettoNowNs();
-        if (lastWavePacketNs !== null) {
-          const deltaNs = packetNs - lastWavePacketNs;
-          if (deltaNs > DEFAULT_WAVE_GAP_NS) {
-            perfettoCapture.recordAlert({
-              type: 'delta_t_oos',
-              channel,
-              value: deltaNs / 1_000_000_000,
-              limit: DEFAULT_WAVE_GAP_NS / 1_000_000_000,
-              unit: 's',
-              deltaNs
-            });
-          }
-        }
-        lastWavePacketNs = packetNs;
-      }
-
-      const result = extractWaveSamples(decoded, runningTimeUs);
-      if (!result) return;
-
-      runningTimeUs = result.nextRunningTimeUs;
-      result.samples.forEach((sample) => {
+    const emitSamples = (samples: WaveSample[]) => {
+      samples.forEach((sample) => {
         writer.writeLine(
           `${sample.timeSeconds.toFixed(6)},${sample.voltage.toFixed(6)},${sample.current.toFixed(6)}`
         );
@@ -621,6 +549,43 @@ async function handleRecordCommand(
           }
         }
       });
+    };
+
+    const unsubscribe = connection.registerPacketHandler(PackType.WAVE, (packet) => {
+      const decoded = decodePacket(packet);
+      if (!decoded || !isWavePacket(decoded)) return;
+
+      if (decoded.data.channel !== channel) {
+        if (!ignoredChannels.has(decoded.data.channel)) {
+          ignoredChannels.add(decoded.data.channel);
+          log(`Ignoring wave data from channel ${decoded.data.channel}.`);
+        }
+        return;
+      }
+
+      if (!hasWaveData) {
+        hasWaveData = true;
+        log(`Receiving wave data for channel ${channel}...`);
+      }
+
+      const packetNs = recordNowNs();
+      if (perfettoCapture && perfettoNowNs && lastWavePacketNs !== null) {
+        const deltaNs = packetNs - lastWavePacketNs;
+        if (deltaNs > DEFAULT_WAVE_GAP_NS) {
+          perfettoCapture.recordAlert({
+            type: 'delta_t_oos',
+            channel,
+            value: deltaNs / 1_000_000_000,
+            limit: DEFAULT_WAVE_GAP_NS / 1_000_000_000,
+            unit: 's',
+            deltaNs
+          });
+        }
+      }
+      lastWavePacketNs = packetNs;
+
+      const adjustedSamples = reconciler.pushPacket(decoded, packetNs);
+      emitSamples(adjustedSamples);
     });
 
     writer.writeLine('time_s,voltage_v,current_a');
@@ -649,6 +614,8 @@ async function handleRecordCommand(
         durationTimer = null;
       }
       unsubscribe();
+      const remainingSamples = reconciler.flushAll();
+      emitSamples(remainingSamples);
       if (unsubscribeRaw) {
         unsubscribeRaw();
       }
@@ -662,7 +629,7 @@ async function handleRecordCommand(
         await writeBinaryFile(perfettoPath, perfettoCapture.serialize());
         log(`Perfetto trace written to ${perfettoPath}.`);
       }
-      const duration = runningTimeUs / 1_000_000;
+      const duration = reconciler.getLastEmittedNs() / 1_000_000_000;
       log(`Recording stopped (${reason}). ${pointCount} samples over ${duration.toFixed(3)}s.`);
       restoreConsole();
       resolveDone?.();

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -23,7 +23,6 @@ import {
   processWavePacket,
   validatePacketChecksum,
   type ChannelUpdate,
-  type DecodedPacket,
   isMachinePacket,
   isWavePacket
 } from '../../webui/src/lib/packet-decoder';

--- a/webui/src/lib/stores/channels.ts
+++ b/webui/src/lib/stores/channels.ts
@@ -3,6 +3,7 @@ import type { Readable, Writable } from 'svelte/store';
 import type { Channel, WaveformPoint } from '../types';
 import { processAddressPacket, processMachinePacket, processSynthesizePacket } from '../packet-decoder';
 import type { AddressPacket, ChannelUpdate, MachinePacket, SynthesizePacket, UpdateChannelPacket, WavePacket } from '../packet-decoder';
+import { WaveTimestampReconciler, type WaveSample } from '../wave-reconciler';
 import { createSetChannelPacket, createSetCurrentPacket, createSetOutputPacket, createSetVoltagePacket } from '../packet-encoder';
 import { debugError } from '../debug-logger';
 import type { PacketBus } from '../services/packet-bus';
@@ -27,6 +28,9 @@ export function createChannelStore(options: { serial: SerialConnection; packets:
   destroy: () => void;
 } {
   const { serial, packets } = options;
+  const DEFAULT_RECONCILE_DELAY_NS = 2_000_000_000;
+  const DEFAULT_RECONCILE_TAIL_NS = 500_000_000;
+  const waveReconcilers = new Map<number, WaveTimestampReconciler>();
 
   const getInitialState = (): Channel[] =>
     Array(6)
@@ -137,32 +141,19 @@ export function createChannelStore(options: { serial: SerialConnection; packets:
     channels.update((chs) => {
       const ch = chs[channel];
       if (!ch || !ch.recording) return chs;
+      const reconciler = waveReconcilers.get(channel)
+        ?? new WaveTimestampReconciler(DEFAULT_RECONCILE_DELAY_NS, DEFAULT_RECONCILE_TAIL_NS);
+      waveReconcilers.set(channel, reconciler);
 
-      if (!ch.runningTimeUs) {
-        ch.runningTimeUs = 0;
-      }
+      const nowNs = Math.round(performance.now() * 1_000_000);
+      const adjustedSamples = reconciler.pushPacket(packet, nowNs);
+      if (adjustedSamples.length === 0) return chs;
 
-      const samplesPerGroup = packet.size === 126 ? 2 : 4;
-      const newPoints: WaveformPoint[] = [];
-
-      packet.data.groups.forEach((group) => {
-        const groupElapsedTimeUs = group.timestamp / 10;
-        const timePerSampleUs = groupElapsedTimeUs / samplesPerGroup;
-
-        for (let i = 0; i < samplesPerGroup; i++) {
-          const item = group.items[i];
-          if (!item) break;
-
-          const sampleTimeUs = (ch.runningTimeUs || 0) + i * timePerSampleUs;
-          newPoints.push({
-            timestamp: sampleTimeUs / 1000,
-            voltage: item.voltage,
-            current: item.current,
-          });
-        }
-
-        ch.runningTimeUs = (ch.runningTimeUs || 0) + groupElapsedTimeUs;
-      });
+      const newPoints = adjustedSamples.map((sample: WaveSample): WaveformPoint => ({
+        timestamp: sample.timeSeconds * 1000,
+        voltage: sample.voltage,
+        current: sample.current
+      }));
 
       if (!ch.waveformData) {
         ch.waveformData = [];
@@ -250,13 +241,34 @@ export function createChannelStore(options: { serial: SerialConnection; packets:
       chs[channel].runningTimeUs = 0;
       return chs;
     });
+    waveReconcilers.set(
+      channel,
+      new WaveTimestampReconciler(DEFAULT_RECONCILE_DELAY_NS, DEFAULT_RECONCILE_TAIL_NS)
+    );
   }
 
   function stopRecording(channel: number): void {
     channels.update((chs) => {
       chs[channel].recording = false;
+      const reconciler = waveReconcilers.get(channel);
+      if (reconciler) {
+        const remaining = reconciler.flushAll();
+        if (remaining.length > 0) {
+          if (!chs[channel].waveformData) {
+            chs[channel].waveformData = [];
+          }
+          chs[channel].waveformData.push(
+            ...remaining.map((sample: WaveSample): WaveformPoint => ({
+              timestamp: sample.timeSeconds * 1000,
+              voltage: sample.voltage,
+              current: sample.current
+            }))
+          );
+        }
+      }
       return chs;
     });
+    waveReconcilers.delete(channel);
   }
 
   function clearRecording(channel: number): void {
@@ -264,12 +276,14 @@ export function createChannelStore(options: { serial: SerialConnection; packets:
       chs[channel].waveformData = [];
       return chs;
     });
+    waveReconcilers.delete(channel);
   }
 
   function reset(): void {
     channels.set(getInitialState());
     activeChannel.set(0);
     waitingSynthesize.set(true);
+    waveReconcilers.clear();
   }
 
   const activeChannelData = derived([channels, activeChannel], ([$channels, $activeChannel]) => $channels[$activeChannel]);

--- a/webui/src/lib/wave-reconciler.ts
+++ b/webui/src/lib/wave-reconciler.ts
@@ -151,7 +151,7 @@ export class WaveTimestampReconciler {
 
       if (this.buffer.length > 0) {
         const first = this.buffer[0];
-        const scale = this.lastMapping?.scale ?? 1;
+        const scale = 1;
         const offsetNs = first.hostNs - scale * first.deviceStartUs * 1000;
         this.lastMapping = { scale, offsetNs };
         return this.lastMapping;

--- a/webui/src/lib/wave-reconciler.ts
+++ b/webui/src/lib/wave-reconciler.ts
@@ -1,0 +1,163 @@
+import { isWavePacket, type DecodedPacket } from './packet-decoder';
+
+type DeviceWaveSample = {
+  deviceTimeUs: number;
+  voltage: number;
+  current: number;
+};
+
+export type WaveSample = {
+  timeSeconds: number;
+  voltage: number;
+  current: number;
+};
+
+type QueuedPacket = {
+  hostNs: number;
+  deviceStartUs: number;
+  deviceEndUs: number;
+  samples: DeviceWaveSample[];
+};
+
+type Mapping = {
+  scale: number;
+  offsetNs: number;
+};
+
+function extractWaveSamples(
+  packet: DecodedPacket,
+  runningTimeUs: number
+): { samples: DeviceWaveSample[]; nextDeviceTimeUs: number } | null {
+  if (!isWavePacket(packet)) return null;
+
+  const wave = packet.data;
+  const samples: DeviceWaveSample[] = [];
+  const samplesPerGroup = packet.size === 126 ? 2 : packet.size === 206 ? 4 : 0;
+
+  wave.groups.forEach((group) => {
+    const groupElapsedTimeUs = group.timestamp / 10;
+    const pointsInGroup = samplesPerGroup || group.items.length || 1;
+    const timePerSampleUs = pointsInGroup > 0 ? groupElapsedTimeUs / pointsInGroup : 0;
+
+    for (let i = 0; i < pointsInGroup; i++) {
+      const item = group.items[i];
+      if (!item) break;
+      const sampleTimeUs = runningTimeUs + i * timePerSampleUs;
+      samples.push({
+        deviceTimeUs: sampleTimeUs,
+        voltage: item.voltage,
+        current: item.current
+      });
+    }
+
+    runningTimeUs += groupElapsedTimeUs;
+  });
+
+  return { samples, nextDeviceTimeUs: runningTimeUs };
+}
+
+export class WaveTimestampReconciler {
+  private readonly delayNs: number;
+  private readonly tailNs: number;
+  private readonly buffer: QueuedPacket[] = [];
+  private deviceCursorUs = 0;
+  private lastEmittedNs = 0;
+  private lastMapping: Mapping | null = null;
+
+  constructor(delayNs: number, tailNs: number) {
+    this.delayNs = delayNs;
+    this.tailNs = tailNs;
+  }
+
+  pushPacket(packet: DecodedPacket, hostNs: number): WaveSample[] {
+    const extracted = extractWaveSamples(packet, this.deviceCursorUs);
+    if (!extracted) return [];
+
+    const { samples, nextDeviceTimeUs } = extracted;
+    const queued: QueuedPacket = {
+      hostNs,
+      deviceStartUs: this.deviceCursorUs,
+      deviceEndUs: nextDeviceTimeUs,
+      samples
+    };
+
+    this.deviceCursorUs = nextDeviceTimeUs;
+    this.buffer.push(queued);
+
+    return this.flush(false);
+  }
+
+  flushAll(): WaveSample[] {
+    return this.flush(true);
+  }
+
+  getLastEmittedNs(): number {
+    return this.lastEmittedNs;
+  }
+
+  private flush(flushAll: boolean): WaveSample[] {
+    if (this.buffer.length === 0) {
+      return [];
+    }
+
+    const mapping = this.computeMapping(flushAll);
+    if (!mapping) {
+      return [];
+    }
+
+    const cutoffHostNs = flushAll
+      ? Number.POSITIVE_INFINITY
+      : this.buffer[this.buffer.length - 1].hostNs - this.tailNs;
+
+    const output: WaveSample[] = [];
+    while (this.buffer.length > 0 && this.buffer[0].hostNs <= cutoffHostNs) {
+      const packet = this.buffer.shift();
+      if (!packet) break;
+      for (const sample of packet.samples) {
+        const adjustedNs = mapping.offsetNs + mapping.scale * sample.deviceTimeUs * 1000;
+        const monotonicNs = Math.max(adjustedNs, this.lastEmittedNs);
+        this.lastEmittedNs = monotonicNs;
+        output.push({
+          timeSeconds: monotonicNs / 1_000_000_000,
+          voltage: sample.voltage,
+          current: sample.current
+        });
+      }
+    }
+
+    return output;
+  }
+
+  private computeMapping(flushAll: boolean): Mapping | null {
+    if (this.buffer.length >= 2) {
+      const first = this.buffer[0];
+      const last = this.buffer[this.buffer.length - 1];
+      const hostSpanNs = last.hostNs - first.hostNs;
+      const deviceSpanUs = last.deviceEndUs - first.deviceStartUs;
+
+      const minSpanNs = flushAll ? 1 : this.delayNs;
+      if (hostSpanNs >= minSpanNs && deviceSpanUs > 0) {
+        const scale = hostSpanNs / (deviceSpanUs * 1000);
+        const offsetNs = first.hostNs - scale * first.deviceStartUs * 1000;
+        this.lastMapping = { scale, offsetNs };
+        return this.lastMapping;
+      }
+    }
+
+    if (flushAll) {
+      if (this.lastMapping) {
+        return this.lastMapping;
+      }
+
+      if (this.buffer.length > 0) {
+        const first = this.buffer[0];
+        const scale = this.lastMapping?.scale ?? 1;
+        const offsetNs = first.hostNs - scale * first.deviceStartUs * 1000;
+        this.lastMapping = { scale, offsetNs };
+        return this.lastMapping;
+      }
+    }
+
+    return null;
+  }
+}

--- a/webui/src/lib/wave-reconciler.ts
+++ b/webui/src/lib/wave-reconciler.ts
@@ -133,12 +133,12 @@ export class WaveTimestampReconciler {
       const first = this.buffer[0];
       const last = this.buffer[this.buffer.length - 1];
       const hostSpanNs = last.hostNs - first.hostNs;
-      const deviceSpanUs = last.deviceEndUs - first.deviceStartUs;
+      const deviceSpanUs = last.deviceEndUs - first.deviceEndUs;
 
       const minSpanNs = flushAll ? 1 : this.delayNs;
       if (hostSpanNs >= minSpanNs && deviceSpanUs > 0) {
         const scale = hostSpanNs / (deviceSpanUs * 1000);
-        const offsetNs = first.hostNs - scale * first.deviceStartUs * 1000;
+        const offsetNs = first.hostNs - scale * first.deviceEndUs * 1000;
         this.lastMapping = { scale, offsetNs };
         return this.lastMapping;
       }
@@ -152,7 +152,7 @@ export class WaveTimestampReconciler {
       if (this.buffer.length > 0) {
         const first = this.buffer[0];
         const scale = 1;
-        const offsetNs = first.hostNs - scale * first.deviceStartUs * 1000;
+        const offsetNs = first.hostNs - scale * first.deviceEndUs * 1000;
         this.lastMapping = { scale, offsetNs };
         return this.lastMapping;
       }

--- a/webui/tests/unit/stores/channels.test.js
+++ b/webui/tests/unit/stores/channels.test.js
@@ -5,11 +5,13 @@ import { createSignal } from '$lib/core/signal.js';
 const mockProcessSynthesizePacket = vi.hoisted(() => vi.fn());
 const mockProcessAddressPacket = vi.hoisted(() => vi.fn());
 const mockProcessMachinePacket = vi.hoisted(() => vi.fn());
+const mockIsWavePacket = vi.hoisted(() => vi.fn((packet) => packet?.packType === 0x12));
 
 vi.mock('$lib/packet-decoder.js', () => ({
   processSynthesizePacket: mockProcessSynthesizePacket,
   processAddressPacket: mockProcessAddressPacket,
   processMachinePacket: mockProcessMachinePacket,
+  isWavePacket: mockIsWavePacket,
 }));
 
 import { createChannelStore } from '$lib/stores/channels.js';
@@ -162,6 +164,9 @@ describe('Channel Store', () => {
     });
 
     it('wave packets append waveform points while recording', () => {
+      const nowSpy = vi.spyOn(globalThis.performance, 'now');
+      nowSpy.mockReturnValueOnce(0);
+      nowSpy.mockReturnValueOnce(3000);
       channelStore.startRecording(2);
 
       packets.onWave.emit({
@@ -180,12 +185,31 @@ describe('Channel Store', () => {
           ],
         },
       });
+      packets.onWave.emit({
+        packType: 0x12,
+        size: 126,
+        data: {
+          channel: 2,
+          groups: [
+            {
+              timestamp: 1000,
+              items: [
+                { voltage: 3.32, current: 0.52 },
+                { voltage: 3.33, current: 0.53 },
+              ],
+            },
+          ],
+        },
+      });
+      nowSpy.mockRestore();
 
       const ch = get(channelStore.channels)[2];
       expect(ch.waveformData.length).toBeGreaterThan(0);
     });
 
     it('stopRecording preserves collected waveform data', () => {
+      const nowSpy = vi.spyOn(globalThis.performance, 'now');
+      nowSpy.mockReturnValueOnce(0);
       channelStore.startRecording(3);
 
       packets.onWave.emit({
@@ -206,6 +230,7 @@ describe('Channel Store', () => {
       });
 
       channelStore.stopRecording(3);
+      nowSpy.mockRestore();
 
       const ch = get(channelStore.channels)[3];
       expect(ch.recording).toBe(false);
@@ -213,6 +238,8 @@ describe('Channel Store', () => {
     });
 
     it('clearRecording removes waveform data', () => {
+      const nowSpy = vi.spyOn(globalThis.performance, 'now');
+      nowSpy.mockReturnValueOnce(0);
       channelStore.startRecording(4);
       packets.onWave.emit({
         packType: 0x12,
@@ -232,6 +259,7 @@ describe('Channel Store', () => {
       });
 
       channelStore.clearRecording(4);
+      nowSpy.mockRestore();
       const ch = get(channelStore.channels)[4];
       expect(ch.waveformData).toHaveLength(0);
     });

--- a/webui/tests/unit/wave-reconciler.test.js
+++ b/webui/tests/unit/wave-reconciler.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { WaveTimestampReconciler } from '$lib/wave-reconciler.js';
+
+function makeWavePacket(groupTimestamp, samples) {
+  return {
+    packType: 0x12,
+    size: 126,
+    data: {
+      channel: 0,
+      groups: [
+        {
+          timestamp: groupTimestamp,
+          items: samples
+        }
+      ]
+    }
+  };
+}
+
+describe('WaveTimestampReconciler', () => {
+  it('aligns device time to host time and emits monotonic samples', () => {
+    const reconciler = new WaveTimestampReconciler(1, 0);
+    const packet1 = makeWavePacket(1000, [
+      { voltage: 1.0, current: 0.1 },
+      { voltage: 1.1, current: 0.2 }
+    ]);
+    const packet2 = makeWavePacket(1000, [
+      { voltage: 1.2, current: 0.3 },
+      { voltage: 1.3, current: 0.4 }
+    ]);
+
+    const first = reconciler.pushPacket(packet1, 0);
+    expect(first).toHaveLength(0);
+
+    const second = reconciler.pushPacket(packet2, 1_000_000_000);
+    expect(second).toHaveLength(4);
+    expect(second.map((sample) => sample.timeSeconds)).toEqual([
+      expect.closeTo(0, 6),
+      expect.closeTo(0.25, 6),
+      expect.closeTo(0.5, 6),
+      expect.closeTo(0.75, 6)
+    ]);
+    expect(second.map((sample) => sample.voltage)).toEqual([1.0, 1.1, 1.2, 1.3]);
+  });
+
+  it('flushes remaining samples when only one packet is buffered', () => {
+    const reconciler = new WaveTimestampReconciler(1_000_000_000, 0);
+    const packet = makeWavePacket(1000, [
+      { voltage: 2.0, current: 0.5 },
+      { voltage: 2.1, current: 0.6 }
+    ]);
+
+    const initial = reconciler.pushPacket(packet, 500_000_000);
+    expect(initial).toHaveLength(0);
+
+    const flushed = reconciler.flushAll();
+    expect(flushed).toHaveLength(2);
+    expect(flushed[0].timeSeconds).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/webui/tests/unit/wave-reconciler.test.js
+++ b/webui/tests/unit/wave-reconciler.test.js
@@ -20,25 +20,25 @@ function makeWavePacket(groupTimestamp, samples) {
 describe('WaveTimestampReconciler', () => {
   it('aligns device time to host time and emits monotonic samples', () => {
     const reconciler = new WaveTimestampReconciler(1, 0);
-    const packet1 = makeWavePacket(1000, [
+    const packet1 = makeWavePacket(1_000_000, [
       { voltage: 1.0, current: 0.1 },
       { voltage: 1.1, current: 0.2 }
     ]);
-    const packet2 = makeWavePacket(1000, [
+    const packet2 = makeWavePacket(1_000_000, [
       { voltage: 1.2, current: 0.3 },
       { voltage: 1.3, current: 0.4 }
     ]);
 
-    const first = reconciler.pushPacket(packet1, 0);
+    const first = reconciler.pushPacket(packet1, 100_000_000);
     expect(first).toHaveLength(0);
 
-    const second = reconciler.pushPacket(packet2, 1_000_000_000);
+    const second = reconciler.pushPacket(packet2, 200_000_000);
     expect(second).toHaveLength(4);
     expect(second.map((sample) => sample.timeSeconds)).toEqual([
       expect.closeTo(0, 6),
-      expect.closeTo(0.25, 6),
-      expect.closeTo(0.5, 6),
-      expect.closeTo(0.75, 6)
+      expect.closeTo(0.05, 6),
+      expect.closeTo(0.1, 6),
+      expect.closeTo(0.15, 6)
     ]);
     expect(second.map((sample) => sample.voltage)).toEqual([1.0, 1.1, 1.2, 1.3]);
   });


### PR DESCRIPTION
## Summary\n- add a shared wave timestamp reconciler that maps device wave time to host time with a bounded delay\n- update CLI recording to emit reconciled samples and flush on stop\n- update WebUI channel store to use reconciled samples and flush on stop\n- add unit tests for the reconciler\n\n## Testing\n- not run (CI only)