### PR TITLE
Fix CLI context channel detection

### DIFF
--- a/cli/src/context-detection.ts
+++ b/cli/src/context-detection.ts
@@ -1,0 +1,107 @@
+import type { ChannelUpdate } from '../../webui/src/lib/packet-decoder';
+import { categorizeDevice, type DeviceCategory, type DeviceContextParams } from './context-registry';
+
+export function isRealMachineType(value?: string): boolean {
+  if (!value) return false;
+  const normalized = value.trim();
+  return !normalized.startsWith('Unknown') && normalized !== 'Node';
+}
+
+export function isLoadMachineType(value?: string): boolean {
+  return (value ?? '').toLowerCase().includes('l1060');
+}
+
+export function isPsuMachineType(value?: string): boolean {
+  return isRealMachineType(value) && !isLoadMachineType(value);
+}
+
+export function selectMachineTypeFromChannels(channels: ChannelUpdate[]): string | null {
+  if (channels.length === 0) {
+    return null;
+  }
+
+  const candidates = channels.filter((channel) => isRealMachineType(channel.machineType));
+  if (candidates.length === 0) {
+    return null;
+  }
+  const onlineCandidates = candidates.filter((channel) => channel.online);
+  const search = onlineCandidates.length > 0 ? onlineCandidates : candidates;
+  const loadMatch = search.find((channel) => isLoadMachineType(channel.machineType));
+
+  if (loadMatch?.machineType) {
+    return loadMatch.machineType;
+  }
+
+  if (search.length > 0) {
+    return search[0].machineType ?? null;
+  }
+
+  const onlineFallback = channels.filter((channel) => channel.online);
+  if (onlineFallback.length > 0) {
+    return onlineFallback[0].machineType ?? null;
+  }
+
+  return channels[0].machineType ?? null;
+}
+
+export function selectChannelFromChannels(
+  channels: ChannelUpdate[],
+  category: DeviceCategory
+): ChannelUpdate | null {
+  if (channels.length === 0) {
+    return null;
+  }
+
+  const online = channels.filter((channel) => channel.online);
+  if (category === 'load') {
+    const loadOnline = online.find((channel) => isLoadMachineType(channel.machineType));
+    if (loadOnline) {
+      return loadOnline;
+    }
+
+    const loadAny = channels.find((channel) => isLoadMachineType(channel.machineType));
+    if (loadAny) {
+      return loadAny;
+    }
+  } else {
+    const psuOnline = online.filter((channel) => isPsuMachineType(channel.machineType));
+    if (psuOnline.length > 0) {
+      return psuOnline[0];
+    }
+
+    const psuAny = channels.filter((channel) => isPsuMachineType(channel.machineType));
+    if (psuAny.length > 0) {
+      return psuAny[0];
+    }
+  }
+
+  const realOnline = online.filter((channel) => isRealMachineType(channel.machineType));
+  if (realOnline.length > 0) {
+    return realOnline[0];
+  }
+
+  if (online.length > 0) {
+    return online[0];
+  }
+
+  const realAny = channels.filter((channel) => isRealMachineType(channel.machineType));
+  if (realAny.length > 0) {
+    return realAny[0];
+  }
+
+  return channels[0];
+}
+
+export function buildContextsFromChannels(
+  portPath: string,
+  channels: ChannelUpdate[]
+): DeviceContextParams[] {
+  return channels
+    .filter((channel) => channel.online && isRealMachineType(channel.machineType))
+    .map((channel) => ({
+      portPath,
+      category: categorizeDevice(channel.machineType ?? 'Unknown'),
+      machineType: channel.machineType ?? 'Unknown',
+      channel: channel.channel
+    }));
+}

--- a/cli/src/context-registry.ts
+++ b/cli/src/context-registry.ts
@@ -9,6 +9,7 @@ export interface DeviceContextParams {
   portPath: string;
   category: DeviceCategory;
   machineType: string;
+  channel?: number;
 }
 
 export interface DeviceContext extends DeviceContextParams {
@@ -46,8 +47,14 @@ export class ContextRegistry {
     });
 
     (['psu', 'load'] as DeviceCategory[]).forEach((category) => {
-      // Sort by portPath for stable ordering across reboots/topology changes
-      const devices = groups[category].sort((a, b) => a.portPath.localeCompare(b.portPath));
+      // Sort by portPath/channel for stable ordering across reboots/topology changes
+      const devices = groups[category].sort((a, b) => {
+        const portCmp = a.portPath.localeCompare(b.portPath);
+        if (portCmp !== 0) return portCmp;
+        const aChannel = a.channel ?? -1;
+        const bChannel = b.channel ?? -1;
+        return aChannel - bChannel;
+      });
       if (devices.length === 0) {
         return;
       }
@@ -71,7 +78,7 @@ export class ContextRegistry {
 
   private pushUnique(context: DeviceContext): void {
     const list = this.uniqueContextsByCategory[context.category];
-    if (!list.some((entry) => entry.portPath === context.portPath)) {
+    if (!list.some((entry) => entry.portPath === context.portPath && entry.channel === context.channel)) {
       list.push(context);
     }
   }
@@ -90,10 +97,17 @@ export class ContextRegistry {
 
   describe(): string[] {
     const lines: string[] = ['Detected device contexts:'];
-    this.getAliases().forEach((alias) => {
-      const ctx = this.aliasMap.get(alias);
-      if (!ctx) return;
-      lines.push(`  ${alias} -> ${ctx.category.toUpperCase()} (${ctx.machineType})`);
+    const sortedContexts = Array.from(this.aliasMap.values()).sort((a, b) => {
+      const aChannel = typeof a.channel === 'number' ? a.channel : Number.POSITIVE_INFINITY;
+      const bChannel = typeof b.channel === 'number' ? b.channel : Number.POSITIVE_INFINITY;
+      if (aChannel !== bChannel) {
+        return aChannel - bChannel;
+      }
+      return a.alias.localeCompare(b.alias);
+    });
+    sortedContexts.forEach((ctx) => {
+      const channel = typeof ctx.channel === 'number' ? ` channel ${ctx.channel}` : '';
+      lines.push(`  ${ctx.alias} -> ${ctx.category.toUpperCase()} (${ctx.machineType})${channel}`);
     });
 
     if (this.ambiguousCategories.size > 0) {

--- a/cli/src/index.ts
+++ b/cli/src/index.ts
@@ -6,7 +6,18 @@ import { get } from 'svelte/store';
 import { NodeSerialConnection } from './node-serial';
 import { ReplaySerialConnection } from './replay-serial';
 import { WaveTimestampReconciler, type WaveSample } from '../../webui/src/lib/wave-reconciler';
-import { ContextRegistry, categorizeDevice, type DeviceContext, type DeviceContextParams } from './context-registry';
+import {
+  ContextRegistry,
+  categorizeDevice,
+  type DeviceCategory,
+  type DeviceContext,
+  type DeviceContextParams
+} from './context-registry';
+import {
+  buildContextsFromChannels,
+  selectChannelFromChannels,
+  selectMachineTypeFromChannels
+} from './context-detection';
 import { createPerfettoCapture, type PerfettoCapture } from '../../webui/src/lib/perfetto-capture';
 import {
   createGetMachinePacket,
@@ -188,10 +199,11 @@ function parseDurationSeconds(value?: string): number | null {
 }
 const STATUS_TIMEOUT_MS = 5000;
 
-async function detectMachineTypeFromSynthesize(
+
+async function fetchSynthesizeChannels(
   connection: NodeSerialConnection,
   timeoutMs = 2500
-): Promise<string | null> {
+): Promise<ChannelUpdate[] | null> {
   try {
     await connection.sendPacket(createHeartbeatPacket());
   } catch {
@@ -213,7 +225,25 @@ async function detectMachineTypeFromSynthesize(
     return null;
   }
 
-  return processed[0].machineType ?? null;
+  return processed;
+}
+
+async function detectChannelFromSynthesize(
+  connection: NodeSerialConnection,
+  category: DeviceCategory,
+  timeoutMs = 2500
+): Promise<{ channel: number; update: ChannelUpdate } | null> {
+  const processed = await fetchSynthesizeChannels(connection, timeoutMs);
+  if (!processed || processed.length === 0) {
+    return null;
+  }
+
+  const selected = selectChannelFromChannels(processed, category);
+  if (!selected) {
+    return null;
+  }
+
+  return { channel: selected.channel, update: selected };
 }
 
 async function discoverDeviceContexts(): Promise<DeviceContextParams[]> {
@@ -226,19 +256,26 @@ async function discoverDeviceContexts(): Promise<DeviceContextParams[]> {
       await connection.connect();
       await connection.sendPacket(createGetMachinePacket());
       const response = await connection.waitForPacket(PackType.MACHINE, 5000);
+      const decoded = response ? decodePacket(response) : null;
+      const info = decoded ? processMachinePacket(decoded) : null;
+
       if (!response) {
-        console.warn(`No machine response from ${port.path}; defaulting to PSU context.`);
-        contexts.push({
-          portPath: port.path,
-          category: 'psu',
-          machineType: 'Unknown'
-        });
+        console.warn(`No machine response from ${port.path}; probing synthesize data instead.`);
+      } else if (!info) {
+        console.warn(`Unable to decode machine packet from ${port.path}; probing synthesize data instead.`);
+      }
+
+      const synthesizeChannels = await fetchSynthesizeChannels(connection);
+      const channelContexts = synthesizeChannels
+        ? buildContextsFromChannels(port.path, synthesizeChannels)
+        : [];
+
+      if (channelContexts.length > 0) {
+        contexts.push(...channelContexts);
         continue;
       }
-      const decoded = decodePacket(response);
-      const info = decoded ? processMachinePacket(decoded) : null;
+
       if (!info) {
-        console.warn(`Unable to decode machine packet from ${port.path}; defaulting to PSU context.`);
         contexts.push({
           portPath: port.path,
           category: 'psu',
@@ -250,13 +287,19 @@ async function discoverDeviceContexts(): Promise<DeviceContextParams[]> {
       const machineData = decoded && isMachinePacket(decoded) ? decoded.data : null;
       const fallbackLabel =
         machineData?.machineName ?? (machineData ? getMachineTypeString(machineData.machineTypeRaw) : undefined);
-      const channelMachineTypes = await detectMachineTypeFromSynthesize(connection);
+      const channelMachineTypes = synthesizeChannels
+        ? selectMachineTypeFromChannels(synthesizeChannels)
+        : null;
       const machineType = channelMachineTypes ?? fallbackLabel ?? info.type;
       const category = categorizeDevice(machineType);
+      const channelHint = synthesizeChannels
+        ? selectChannelFromChannels(synthesizeChannels, category)
+        : null;
       contexts.push({
         portPath: port.path,
         category,
-        machineType
+        machineType,
+        channel: channelHint?.channel
       });
     } catch (error) {
       console.warn(`Failed to probe ${port.path}:`, error instanceof Error ? error.message : error);
@@ -313,7 +356,6 @@ async function handleContextCommand(
   options: ContextCommandOptions,
   outputState?: string
 ): Promise<void> {
-  const channel = parseChannelArg(options.channel ?? '0');
   const wantsStatus = Boolean(options.status || options.statusJson);
   const wantsSets = Boolean(options.setVoltage || options.setCurrent);
   const wantsOutput = typeof outputState === 'string';
@@ -328,9 +370,32 @@ async function handleContextCommand(
   const connection = new NodeSerialConnection({ portPath: context.portPath });
   await connection.connect();
   try {
-    const baseline = wantsStatus || wantsSets ? await waitForChannelStatus(connection, channel) : null;
-    if ((wantsStatus || wantsSets) && !baseline) {
-      throw new Error('No synthesize data received yet for the requested channel');
+    let channel: number;
+    let baseline: ChannelUpdate | null = null;
+
+    if (options.channel !== undefined) {
+      channel = parseChannelArg(options.channel);
+    } else if (typeof context.channel === 'number') {
+      channel = context.channel;
+    } else {
+      const detected = await detectChannelFromSynthesize(connection, context.category);
+      if (detected) {
+        channel = detected.channel;
+        baseline = detected.update;
+      } else if (context.category === 'load') {
+        throw new Error('Unable to auto-detect device channel; pass --channel explicitly.');
+      } else {
+        channel = 0;
+      }
+    }
+
+    if (wantsStatus || wantsSets) {
+      if (!baseline) {
+        baseline = await waitForChannelStatus(connection, channel);
+      }
+      if (!baseline) {
+        throw new Error('No synthesize data received yet for the requested channel');
+      }
     }
 
     const parsedVoltage = options.setVoltage !== undefined ? Number(options.setVoltage) : undefined;
@@ -440,7 +505,7 @@ async function handleRecordCommand(
     process.stderr.write(`${format(...args)}\n`);
   };
 
-  const channel = parseChannelArg('0');
+  let channel = typeof context.channel === 'number' ? context.channel : 0;
   const durationSeconds = parseDurationSeconds(options.duration);
   const outputPath = options.outputCsv;
   const perfettoPath = options.outputPerfetto;
@@ -497,6 +562,16 @@ async function handleRecordCommand(
   try {
     await connection.connect();
     if (!replayPerfettoPath) {
+      if (typeof context.channel !== 'number') {
+        const detected = connection instanceof NodeSerialConnection
+          ? await detectChannelFromSynthesize(connection, context.category)
+          : null;
+        if (detected) {
+          channel = detected.channel;
+        } else if (context.category === 'load') {
+          throw new Error('Unable to auto-detect device channel; run `devices` and choose the correct device alias.');
+        }
+      }
       await connection.sendPacket(createSetChannelPacket(channel));
       await delay(50);
       connection.startHeartbeat(() => createHeartbeatPacket(), 1000);
@@ -685,7 +760,7 @@ function registerContextCommands(program: Command, registry: ContextRegistry): v
       .command(alias)
       .description(`Control ${context.machineType} (${alias})`)
       .argument('[state]', 'Output state (on/off)')
-      .option('--channel <number>', 'Channel index (0-5)', '0')
+      .option('--channel <number>', 'Channel index (0-5)')
       .option('--status', 'Print textual status')
       .option('--status-json', 'Print JSON status')
       .option('--set-voltage <voltage>', 'Set target voltage (V)')
@@ -703,6 +778,23 @@ function registerContextCommands(program: Command, registry: ContextRegistry): v
       .option('--replay-perfetto <path>', 'Replay raw chunks from a Perfetto trace instead of live serial')
       .action(async (options: RecordCommandOptions) => {
         await handleRecordCommand(alias, context, options);
+      });
+  });
+
+  (['psu', 'load'] as DeviceCategory[]).forEach((category) => {
+    if (registry.getAmbiguousCategories().includes(category)) {
+      return;
+    }
+    if (registry.getContext(category)) {
+      return;
+    }
+    program
+      .command(category)
+      .description(`No ${category.toUpperCase()} device detected`)
+      .action(() => {
+        throw new Error(
+          `No ${category.toUpperCase()} device detected. Run \`devices\` to list available contexts.`
+        );
       });
   });
 }

--- a/cli/tests/context-detection.test.ts
+++ b/cli/tests/context-detection.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import type { ChannelUpdate } from '../../webui/src/lib/packet-decoder';
+import {
+  buildContextsFromChannels,
+  selectChannelFromChannels,
+  selectMachineTypeFromChannels
+} from '../src/context-detection';
+
+const makeChannel = (overrides: Partial<ChannelUpdate>): ChannelUpdate => ({
+  channel: 0,
+  online: true,
+  machineType: 'P906',
+  ...overrides
+});
+
+describe('context detection helpers', () => {
+  it('should build contexts for PSU and Load channels on one port', () => {
+    const channels: ChannelUpdate[] = [
+      makeChannel({ channel: 0, machineType: 'P906' }),
+      makeChannel({ channel: 1, machineType: 'L1060' })
+    ];
+
+    const contexts = buildContextsFromChannels('/dev/ttyUSB0', channels);
+
+    expect(contexts).toHaveLength(2);
+    expect(contexts).toEqual(
+      expect.arrayContaining([
+        {
+          portPath: '/dev/ttyUSB0',
+          category: 'psu',
+          machineType: 'P906',
+          channel: 0
+        },
+        {
+          portPath: '/dev/ttyUSB0',
+          category: 'load',
+          machineType: 'L1060',
+          channel: 1
+        }
+      ])
+    );
+  });
+
+  it('should ignore Unknown/Node channels when building contexts', () => {
+    const channels: ChannelUpdate[] = [
+      makeChannel({ channel: 0, machineType: 'Unknown' }),
+      makeChannel({ channel: 1, machineType: 'Node' })
+    ];
+
+    const contexts = buildContextsFromChannels('/dev/ttyUSB0', channels);
+
+    expect(contexts).toHaveLength(0);
+  });
+
+  it('should ignore offline channels when building contexts', () => {
+    const channels: ChannelUpdate[] = [
+      makeChannel({ channel: 0, machineType: 'P906', online: false }),
+      makeChannel({ channel: 1, machineType: 'L1060', online: false })
+    ];
+
+    const contexts = buildContextsFromChannels('/dev/ttyUSB0', channels);
+
+    expect(contexts).toHaveLength(0);
+  });
+
+  it('should select the correct channel for load vs psu', () => {
+    const channels: ChannelUpdate[] = [
+      makeChannel({ channel: 1, machineType: 'L1060' }),
+      makeChannel({ channel: 0, machineType: 'P906' })
+    ];
+
+    expect(selectChannelFromChannels(channels, 'load')?.channel).toBe(1);
+    expect(selectChannelFromChannels(channels, 'psu')?.channel).toBe(0);
+  });
+
+  it('should return null when no real machine types are present', () => {
+    const channels: ChannelUpdate[] = [
+      makeChannel({ channel: 0, machineType: 'Unknown' }),
+      makeChannel({ channel: 1, machineType: 'Node' })
+    ];
+
+    expect(selectMachineTypeFromChannels(channels)).toBeNull();
+  });
+});

--- a/cli/tests/context-registry.test.ts
+++ b/cli/tests/context-registry.test.ts
@@ -223,6 +223,19 @@ describe('ContextRegistry', () => {
       expect(registry.uniqueContextsByCategory.psu).toHaveLength(2);
       expect(registry.uniqueContextsByCategory.load).toHaveLength(0);
     });
+
+    it('should keep channels from the same port as unique entries', () => {
+      const contexts: DeviceContextParams[] = [
+        { portPath: '/dev/ttyUSB0', category: 'psu', machineType: 'P906', channel: 0 },
+        { portPath: '/dev/ttyUSB0', category: 'psu', machineType: 'P906', channel: 1 }
+      ];
+
+      const registry = new ContextRegistry(contexts);
+
+      expect(registry.uniqueContextsByCategory.psu).toHaveLength(2);
+      expect(registry.getContext('psu1')?.channel).toBe(0);
+      expect(registry.getContext('psu2')?.channel).toBe(1);
+    });
   });
 
   describe('describe()', () => {
@@ -267,6 +280,17 @@ describe('ContextRegistry', () => {
 
       expect(description).toContain('  psu (use psu1, psu2)');
       expect(description).toContain('  load (use load1, load2)');
+    });
+
+    it('should include channel numbers when available', () => {
+      const contexts: DeviceContextParams[] = [
+        { portPath: '/dev/ttyUSB0', category: 'load', machineType: 'L1060', channel: 1 }
+      ];
+
+      const registry = new ContextRegistry(contexts);
+      const description = registry.describe();
+
+      expect(description).toContain('  load -> LOAD (L1060) channel 1');
     });
   });
 
@@ -325,6 +349,18 @@ describe('ContextRegistry', () => {
       // Both registries should have same ordering despite different input order
       expect(registry1.getContext('load1')?.portPath).toBe('/dev/ttyUSB1');
       expect(registry2.getContext('load1')?.portPath).toBe('/dev/ttyUSB1');
+    });
+
+    it('should order channels consistently for the same port', () => {
+      const contexts: DeviceContextParams[] = [
+        { portPath: '/dev/ttyUSB0', category: 'load', machineType: 'L1060', channel: 1 },
+        { portPath: '/dev/ttyUSB0', category: 'load', machineType: 'L1060', channel: 0 }
+      ];
+
+      const registry = new ContextRegistry(contexts);
+
+      expect(registry.getContext('load1')?.channel).toBe(0);
+      expect(registry.getContext('load2')?.channel).toBe(1);
     });
   });
 });


### PR DESCRIPTION
## Summary
- build contexts only from online synthesize channels and avoid overriding machine type with Unknown/Node
- sort devices output by channel and keep per-channel contexts stable
- remove record --channel flag and rely on psu1/psu2/load1/load2 disambiguation
- add regression tests for context detection and channel-aware ordering

## Testing
- npm run test -- context-detection.test.ts context-registry.test.ts
- npm run lint
- npm run type-check